### PR TITLE
fix for empty source string

### DIFF
--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -203,7 +203,8 @@ create.nc <- function(filename, clobber = TRUE, share = FALSE, prefill = TRUE,
   stopifnot(is.logical(prefill))
   stopifnot(is.character(format))
   stopifnot(is.logical(large))
-
+  stopifnot(nchar(filename) > 0L)
+  
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_create, filename, clobber, share, prefill, format)
   
@@ -292,6 +293,7 @@ open.nc <- function(con, write = FALSE, share = FALSE, prefill = TRUE, ...) {
   stopifnot(is.logical(write))
   stopifnot(is.logical(share))
   stopifnot(is.logical(prefill))
+  stopifnot(nchar(con) > 0L)
   
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_open, con, write, share, prefill)


### PR DESCRIPTION
Simple stop catch for empty string "" to `open.nc` or `create.nc`. 

Fixes #18 

```R
library(RNetCDF)

## both of these cause segfault (tested only on Ubuntu)
#a <- open.nc("")
#a <- create.nc("")

# R version 3.4.3 (2017-11-30)
# Platform: x86_64-pc-linux-gnu (64-bit)
# Running under: Debian GNU/Linux buster/sid
# 
# Matrix products: default
# BLAS: /usr/lib/x86_64-linux-gnu/blas/libblas.so.3.7.1
# LAPACK: /usr/lib/x86_64-linux-gnu/lapack/liblapack.so.3.7.1
# 
# locale:
#  [1] LC_CTYPE=en_AU.UTF-8       LC_NUMERIC=C              
#  [3] LC_TIME=en_AU.UTF-8        LC_COLLATE=en_AU.UTF-8    
#  [5] LC_MONETARY=en_AU.UTF-8    LC_MESSAGES=en_AU.UTF-8   
#  [7] LC_PAPER=en_AU.UTF-8       LC_NAME=C                 
#  [9] LC_ADDRESS=C               LC_TELEPHONE=C            
# [11] LC_MEASUREMENT=en_AU.UTF-8 LC_IDENTIFICATION=C       
# 
# attached base packages:
# [1] stats     graphics  grDevices utils     datasets  methods  
# [7] base     
# 
# other attached packages:
# [1] RNetCDF_2.0-1   devtools_1.13.4
# 
# loaded via a namespace (and not attached):
# [1] compiler_3.4.3 tools_3.4.3    withr_2.1.1    yaml_2.1.16   
# [5] memoise_1.1.0  digest_0.6.15 
```