### PR TITLE
Allow reading and writing of bit64 integers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,7 @@ Author: Pavel Michna, with contributions from Milton Woods
 Maintainer: Milton Woods <miltonjwoods@gmail.com>
 Depends: R (>= 3.0.0)
 SystemRequirements: netcdf udunits-2
+Suggests: bit64
 Description: An interface to the NetCDF file format designed by Unidata
   for efficient storage of array-oriented scientific data and descriptions.
   This R interface is closely based on the C API of the NetCDF library,

--- a/man/att.get.nc.Rd
+++ b/man/att.get.nc.Rd
@@ -13,7 +13,19 @@
   \item{variable}{ID or name of the variable from which the attribute will be read, or \code{"NC_GLOBAL"} for a global attribute.}
   \item{attribute}{Attribute name or ID.}
   \item{rawchar}{This option only relates to NetCDF attributes of type \code{NC_CHAR}. When \code{rawchar} is \code{FALSE} (default), a NetCDF attribute of type \code{NC_CHAR} is converted to a \code{character} string in R. If \code{rawchar} is \code{TRUE}, the bytes of \code{NC_CHAR} data are read into an R \code{raw} vector.}
-  \item{fitnum}{By default, all numeric variables are read into R as double precision values. When \code{fitnum==TRUE}, the smallest R type that can exactly represent each external type is used. Types \code{NC_BYTE}, \code{NC_UBYTE}, \code{NC_SHORT}, \code{NC_USHORT} and \code{NC_INT} are read as R integer values, which require half the memory of double precision. \code{NC_UINT} is always read as double precision to avoid integer overflow. Due to the lack of native support for 64-bit integers in R, \code{NC_INT64} and \code{NC_UINT64} are stored as R character vectors in decimal format.}
+  \item{fitnum}{By default, all numeric variables are read into R as double precision values. When \code{fitnum==TRUE}, the smallest R numeric type that can exactly represent each external type is used, as follows:
+  \tabular{ll}{
+    \code{NC_BYTE}       \tab \code{\link[base]{integer}} \cr
+    \code{NC_UBYTE}      \tab \code{\link[base]{integer}} \cr
+    \code{NC_SHORT}      \tab \code{\link[base]{integer}} \cr
+    \code{NC_USHORT}     \tab \code{\link[base]{integer}} \cr
+    \code{NC_INT}        \tab \code{\link[base]{integer}} \cr
+    \code{NC_UINT}       \tab \code{\link[base]{double}} \cr
+    \code{NC_FLOAT}      \tab \code{\link[base]{double}} \cr
+    \code{NC_DOUBLE}     \tab \code{\link[base]{double}} \cr
+    \code{NC_INT64}      \tab \code{\link[bit64]{integer64}} \cr
+    \code{NC_UINT64}     \tab \code{\link[bit64]{integer64}} \cr
+  }}
 }
 
 \value{Vector with a data type that depends on the NetCDF variable. For NetCDF variables of type \code{NC_CHAR}, the R type is either \code{character} or \code{raw}, as specified by argument \code{rawchar}. For \code{NC_STRING}, the R type is \code{character}. Numeric variables are read as double precision by default, but the smallest R type that exactly represents each external type is used if \code{fitnum} is \code{TRUE}.}

--- a/man/var.get.nc.Rd
+++ b/man/var.get.nc.Rd
@@ -18,7 +18,19 @@
   \item{collapse}{\code{TRUE} if degenerated dimensions (length=1) should be omitted.}
   \item{unpack}{Packed variables are unpacked if \code{unpack=TRUE} and the attributes \code{add_offset} and \code{scale_factor} are defined. Default is \code{FALSE}.}
   \item{rawchar}{This option only relates to NetCDF variables of type \code{NC_CHAR}. When \code{rawchar} is \code{FALSE} (default), a NetCDF variable of type \code{NC_CHAR} is converted to a \code{character} array in R. The \code{character} values are from the fastest-varying dimension of the NetCDF variable, so that the R \code{character} array has one fewer dimensions than the \code{NC_CHAR} array. If \code{rawchar} is \code{TRUE}, the bytes of \code{NC_CHAR} data are read into an R \code{raw} array of the same shape.}
-  \item{fitnum}{By default, all numeric variables are read into R as double precision values. When \code{fitnum==TRUE}, the smallest R type that can exactly represent each external type is used. Types \code{NC_BYTE}, \code{NC_UBYTE}, \code{NC_SHORT}, \code{NC_USHORT} and \code{NC_INT} are read as R integer values, which require half the memory of double precision. \code{NC_UINT} is always read as double precision to avoid integer overflow. Due to the lack of native support for 64-bit integers in R, \code{NC_INT64} and \code{NC_UINT64} are stored as R character vectors in decimal format.}
+  \item{fitnum}{By default, all numeric variables are read into R as double precision values. When \code{fitnum==TRUE}, the smallest R numeric type that can exactly represent each external type is used, as follows:
+  \tabular{ll}{
+    \code{NC_BYTE}       \tab \code{\link[base]{integer}} \cr
+    \code{NC_UBYTE}      \tab \code{\link[base]{integer}} \cr
+    \code{NC_SHORT}      \tab \code{\link[base]{integer}} \cr
+    \code{NC_USHORT}     \tab \code{\link[base]{integer}} \cr
+    \code{NC_INT}        \tab \code{\link[base]{integer}} \cr
+    \code{NC_UINT}       \tab \code{\link[base]{double}} \cr
+    \code{NC_FLOAT}      \tab \code{\link[base]{double}} \cr
+    \code{NC_DOUBLE}     \tab \code{\link[base]{double}} \cr
+    \code{NC_INT64}      \tab \code{\link[bit64]{integer64}} \cr
+    \code{NC_UINT64}     \tab \code{\link[bit64]{integer64}} \cr
+  }}
 }
 
 \details{

--- a/src/convert.c
+++ b/src/convert.c
@@ -89,6 +89,19 @@ static const double ULLONG_MAX_DBL = \
 static const double SIZE_MAX_DBL = \
   ((double) SIZE_MAX) * (1.0 - DBL_EPSILON);
 
+/* Definitions for integer64 as provided by bit64 package */
+int isInt64(SEXP rv) {
+  int status=-1, ii;
+  SEXP class;
+  class = getAttrib(rv, R_ClassSymbol);
+  if (isString(class)) {
+    for (ii=0; ii<length(class); ii++) {
+      status = strcmp(CHAR(STRING_ELT(class, ii)), "integer64");
+      if (status == 0) break;
+    }
+  }
+  return (status == 0);
+}
 
 /*=============================================================================*\
  *  String conversions and other operations.

--- a/src/convert.h
+++ b/src/convert.h
@@ -39,6 +39,11 @@
 
 #define NA_SIZE SIZE_MAX
 
+/* Definitions for integer64 as provided by bit64 package */
+#define NA_INTEGER64 LLONG_MIN
+int isInt64(SEXP rv);
+
+
 /* TODO: roll these into R_nc_r2c and R_nc_c2r */
 
 void

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -38,6 +38,7 @@
 #  mw       05/09/14   Test reading/writing NC_CHAR as raw bytes
 #  mw       26/01/16   Test utcal.nc and utinvcal.nc with POSIXct type
 #  mw       13/02/16   Test file operations in all supported on-disk formats
+#  mw       17/06/18   Test bit64 operations
 #
 #===============================================================================#
 
@@ -47,7 +48,7 @@
 #===============================================================================#
 
 library(RNetCDF)
-
+has_bit64 <- require(bit64)
 
 #===============================================================================#
 #  Run tests
@@ -115,7 +116,9 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
 
   if (format == "netcdf4") {
     var.def.nc(nc, "namestr", "NC_STRING", c("station"))
-    var.def.nc(nc, "stationid", "NC_UINT64", c("station"))
+    if (has_bit64) {
+      var.def.nc(nc, "stationid", "NC_UINT64", c("station"))
+    }
   }
 
   ##  Put some missing_value attribute for temperature
@@ -128,13 +131,15 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   ## Define some additional test attributes:
   att_text <- "This is some text"
   att_text2 <- c("This is string 1", "This is string 2")
-  hugeint <- "-1234567890123456789"
   att.put.nc(nc, "NC_GLOBAL", "char_att", "NC_CHAR", att_text)
   att.put.nc(nc, "name", "char_att", "NC_CHAR", att_text)
   att.put.nc(nc, "name", "raw_att", "NC_CHAR", charToRaw(att_text))
   if (format == "netcdf4") {
     att.put.nc(nc, "temperature", "string_att", "NC_STRING", att_text2)
-    att.put.nc(nc, "temperature", "int64_att", "NC_INT64", hugeint)
+    if (has_bit64) {
+      hugeint <- as.integer64("-1234567890123456789")
+      att.put.nc(nc, "temperature", "int64_att", "NC_INT64", hugeint)
+    }
   }
 
   ##  Define variable values
@@ -142,7 +147,6 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   mytemperature <- matrix(c(1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, NA, NA, 9.9),ncol=ntime)
   mypackvar     <- seq_len(5)*10-5
   myname        <- c("alfa", "bravo", "charlie", "delta", "echo")
-  myid          <- paste("1234567890123456789",c("0","1","2","3","4"),sep="")
   myqcflag      <- "ABCDE"
   myint0        <- 12345
   mychar0       <- "?"
@@ -158,7 +162,10 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
 
   if (format == "netcdf4") {
     var.put.nc(nc, "namestr", myname)
-    var.put.nc(nc, "stationid", myid)
+    if (has_bit64) {
+      myid <- as.integer64("1234567890123456789")+c(0,1,2,3,4)
+      var.put.nc(nc, "stationid", myid)
+    }
   }
 
   sync.nc(nc)
@@ -186,15 +193,17 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
     y <- att.get.nc(nc, "temperature", "string_att")
     tally <- testfun(x,y,tally)
 
-    cat("Read NC_INT64 variable attribute as character ...")
-    x <- hugeint
-    y <- att.get.nc(nc, "temperature", "int64_att", fitnum=TRUE)
-    tally <- testfun(x,y,tally)
+    if (has_bit64) {
+      cat("Read NC_INT64 variable attribute ...")
+      x <- hugeint
+      y <- att.get.nc(nc, "temperature", "int64_att", fitnum=TRUE)
+      tally <- testfun(x,y,tally)
 
-    cat("Read NC_INT64 variable attribute as numeric ...")
-    x <- as.numeric(hugeint)
-    y <- att.get.nc(nc, "temperature", "int64_att")
-    tally <- testfun(x,y,tally)
+      cat("Read NC_INT64 variable attribute as numeric ...")
+      x <- suppressWarnings(as.numeric(hugeint))
+      y <- att.get.nc(nc, "temperature", "int64_att")
+      tally <- testfun(x,y,tally)
+    }
   }
 
   grpinfo <- grp.inq.nc(nc)
@@ -323,11 +332,13 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
     y <- var.get.nc(nc, "namestr", c(2), c(2))
     tally <- testfun(x,y,tally)
 
-    cat("Read 1D int64 array as characters ...")
-    x <- myid
-    dim(x) <- length(x)
-    y <- var.get.nc(nc, "stationid", fitnum=TRUE)
-    tally <- testfun(x,y,tally)
+    if (has_bit64) {
+      cat("Read 1D int64 array as integer64 ...")
+      x <- myid
+      dim(x) <- length(x)
+      y <- var.get.nc(nc, "stationid", fitnum=TRUE)
+      tally <- testfun(x,y,tally)
+    }
   }
 
   cat("Read and unpack numeric array ... ")


### PR DESCRIPTION
Package bit64 provides type `integer64`, which is a space-efficient and flexible way to represent large integers. Various conversions and numeric operations (as signed 64-bit integers) are supported by `integer64` within R. This PR adds support for `integer64` in RNetCDF while dropping support for large integers expressed as character vectors. 