### PR TITLE
Support inquiries about user-defined types

### DIFF
--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -915,6 +915,22 @@ type.insert.nc <- function(ncfile, type, name, value=NULL,
 }
 
 
+#-------------------------------------------------------------------------------
+# type.inq.nc()
+#-------------------------------------------------------------------------------
+
+type.inq.nc <- function(ncfile, type, fields=TRUE) {
+  # Check arguments:
+  stopifnot(class(ncfile) == "NetCDF")
+  stopifnot(is.numeric(type) || is.character(type))
+  stopifnot(is.logical(fields))
+  
+  result <- .Call(R_nc_inq_type, ncfile, type, fields)
+
+  return(result)
+}
+
+
 # ===============================================================================
 # Udunits library functions
 # ===============================================================================

--- a/man/type.inq.nc.Rd
+++ b/man/type.inq.nc.Rd
@@ -1,0 +1,72 @@
+\name{type.inq.nc}
+
+\alias{type.inq.nc}
+
+\title{Inquire About a NetCDF Type}
+
+\description{Inquire about a NetCDF builtin or user-defined data type.}
+
+\usage{type.inq.nc(ncfile, type, fields=TRUE)}
+
+\arguments{
+  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset or group.}
+  \item{type}{ID or name of a NetCDF data type.}
+  \item{fields}{Read members of enum types or fields of compound types (default \code{TRUE})}.
+}
+
+\value{
+  A list containing the following components:
+  \item{id}{Type ID.}
+  \item{name}{Type name.}
+  \item{class}{One of the keywords "builtin", "compound", "enum", "opaque" or "vlen".}
+  \item{size}{Size in bytes of a single item of the type (or a single element of a "vlen").}
+  \item{basetype}{("enum" or "vlen") Name of the NetCDF type of each element.}
+
+  If \code{fields=TRUE}, the return list includes details about members of enum types or fields of compound types:
+  \item{value}{("enum" only) Named vector with numeric values of all members.}
+  \item{offset}{("compound" only) Named vector with the offset of each field in bytes from the beginning of the compound type.}
+  \item{subtype}{("compound" only) Named vector with the NetCDF type name of each field.}
+  \item{dimsizes}{("compound" only) Named list with array dimensions of each field. Dimension lengths are reported in R order (leftmost index varies fastest; opposite to CDL conventions). A \code{NULL} length indicates a scalar.}
+}
+
+\details{This function obtains information about a NetCDF data type, which could be builtin or user-defined. The items in the return list depend on the class of the NetCDF type.}
+
+\references{\url{http://www.unidata.ucar.edu/software/netcdf/}}
+
+\author{Milton Woods}
+
+\seealso{
+  \code{\link{grp.inq.nc}} - get a list of NetCDF types defined in a dataset or group.
+  \code{\link{type.def.nc}} - define a new NetCDF type.
+  \code{\link{type.insert.nc}} - define components of an "enum" or "compound" type.
+}
+
+\examples{
+##  Create a new NetCDF4 dataset and define types
+nc <- create.nc("type.inq.nc", format="netcdf4")
+
+# Define a type of each class:
+type.def.nc(nc, "blob", "opaque", size=128)
+type.def.nc(nc, "vector", "vlen", basetype="NC_FLOAT")
+
+type.def.nc(nc, "factor", "enum", basetype="NC_INT")
+type.insert.nc(nc, "factor", "peanut butter", value=101)
+type.insert.nc(nc, "factor", "jelly", value=102)
+
+type.def.nc(nc, "struct", "compound", size=4+8+3*2)
+type.insert.nc(nc, "struct", "siteid", offset=0, subtype="NC_INT")
+type.insert.nc(nc, "struct", "height", offset=4, subtype="NC_DOUBLE")
+type.insert.nc(nc, "struct", "colour", offset=12, subtype="NC_SHORT", dimsizes=c(3))
+
+# Inquire about the types:
+typeids <- grp.inq.nc(nc)$typeids
+
+for (typeid in typeids) {
+  print(type.inq.nc(nc, typeid))
+}
+
+close.nc(nc)
+}
+
+\keyword{file}
+

--- a/src/RNetCDF.h
+++ b/src/RNetCDF.h
@@ -131,6 +131,9 @@ SEXP
 R_nc_insert_type (SEXP nc, SEXP type, SEXP name, SEXP value,
   SEXP offset, SEXP subtype, SEXP dimsizes);
 
+SEXP
+R_nc_inq_type (SEXP nc, SEXP type, SEXP fields);
+
 
 /* Units */
 

--- a/src/attribute.c
+++ b/src/attribute.c
@@ -428,10 +428,12 @@ R_nc_put_att (SEXP nc, SEXP var, SEXP att, SEXP type, SEXP data)
       if (isInt64 (data)) {
         if (xtype == NC_UINT64) {
           /* Preserve full range of unsigned long long */
-          R_nc_check (nc_put_att_ulonglong (ncid, varid, attname, xtype, cnt, REAL (data)));
+          R_nc_check (nc_put_att_ulonglong (ncid, varid, attname, xtype, cnt,
+                      (unsigned long long *) REAL (data)));
         } else {
           /* R integer64 is usually signed */
-          R_nc_check (nc_put_att_longlong (ncid, varid, attname, xtype, cnt, REAL (data)));
+          R_nc_check (nc_put_att_longlong (ncid, varid, attname, xtype, cnt,
+                      (long long *) REAL (data)));
         }
       } else {
         R_nc_check (nc_put_att_double (ncid, varid, attname, xtype, cnt, REAL (data)));

--- a/src/common.c
+++ b/src/common.c
@@ -128,6 +128,20 @@ R_nc_var_id (SEXP var, int ncid, int *varid)
 
 
 int
+R_nc_type_id (SEXP type, int ncid, nc_type *xtype)
+{
+  if (isNumeric (type)) {
+    *xtype = asInteger (type);
+    return NC_NOERR;
+  } else if (isString (type)) {
+    return R_nc_str2type (ncid, CHAR (STRING_ELT (type, 0)), xtype);
+  } else {
+    return NC_EINVAL;
+  }
+}
+
+
+int
 R_nc_type2str (int ncid, nc_type xtype, char *typename)
 {
   char *str;

--- a/src/common.h
+++ b/src/common.h
@@ -78,6 +78,12 @@ R_nc_dim_id (SEXP dim, int ncid, int *dimid, int idx);
 int
 R_nc_var_id (SEXP var, int ncid, int *varid);
 
+/* Convert type identifier from R string or number to an integer.
+   Result is a netcdf status value.
+ */
+int
+R_nc_type_id (SEXP type, int ncid, nc_type *xtype);
+
 /* Convert netcdf type code to string label.
    Return NC_NOERR if ok, netcdf error code otherwise.
    The string buffer is assumed to have length NC_MAX_NAME or more.

--- a/src/init.c
+++ b/src/init.c
@@ -64,6 +64,7 @@ static const R_CallMethodDef callMethods[]  = {
   {"R_nc_rename_grp", (DL_FUNC) &R_nc_rename_grp, 2},
   {"R_nc_def_type", (DL_FUNC) &R_nc_def_type, 5},
   {"R_nc_insert_type", (DL_FUNC) &R_nc_insert_type, 7},
+  {"R_nc_inq_type", (DL_FUNC) &R_nc_inq_type, 3},
   {"R_nc_calendar", (DL_FUNC) &R_nc_calendar, 2},
   {"R_nc_utinit", (DL_FUNC) &R_nc_utinit, 1},
   {"R_nc_inv_calendar", (DL_FUNC) &R_nc_inv_calendar, 2},

--- a/src/variable.c
+++ b/src/variable.c
@@ -680,10 +680,12 @@ R_nc_put_var (SEXP nc, SEXP var, SEXP start, SEXP count, SEXP data)
       if (isInt64 (data)) {
         if (xtype == NC_UINT64) {
           /* Preserve full range of unsigned long long */
-          R_nc_check (nc_put_vara_ulonglong (ncid, varid, cstart, ccount, REAL (data)));
+          R_nc_check (nc_put_vara_ulonglong (ncid, varid, cstart, ccount,
+                      (unsigned long long *) REAL (data)));
         } else {
           /* R integer64 is usually signed */
-          R_nc_check (nc_put_vara_longlong (ncid, varid, cstart, ccount, REAL (data)));
+          R_nc_check (nc_put_vara_longlong (ncid, varid, cstart, ccount,
+                      (long long *) REAL (data)));
         }
       } else {
         R_nc_check (nc_put_vara_double (ncid, varid, cstart, ccount, REAL (data)));

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -110,7 +110,7 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
 
     id_vector <- type.def.nc(nc, "vector", "vlen", basetype="NC_FLOAT")
     inq_vector <- list(id=id_vector, name="vector", class="vlen",
-                       size=16, basetype="NC_FLOAT")
+                       size=NA, basetype="NC_FLOAT")
 
     id_factor <- type.def.nc(nc, "factor", "enum", basetype="NC_INT")
     type.insert.nc(nc, "factor", "peanut butter", value=101)
@@ -374,8 +374,9 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
     y <- type.inq.nc(nc, id_blob)
     tally <- testfun(x,y,tally)
 
-    x <- inq_vector
-    y <- type.inq.nc(nc, id_vector)
+    # Reported size may depend on netcdf version and pointer size:
+    x <- inq_vector[-4]
+    y <- type.inq.nc(nc, id_vector)[-4]
     tally <- testfun(x,y,tally)
 
     x <- inq_factor

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -39,6 +39,7 @@
 #  mw       26/01/16   Test utcal.nc and utinvcal.nc with POSIXct type
 #  mw       13/02/16   Test file operations in all supported on-disk formats
 #  mw       17/06/18   Test bit64 operations
+#  mw       14/07/18   Test type definition and inquiry functions
 #
 #===============================================================================#
 
@@ -98,10 +99,34 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   dim.def.nc(nc, "max_string_length", nstring)
   dim.def.nc(nc, "empty", unlim=TRUE)
 
-  ## Define a group
   if (format == "netcdf4") {
+    ## Define a group
     ncroot <- nc
     nc <- grp.def.nc(nc, "testgrp")
+
+    ## Define a type of each class:
+    id_blob <- type.def.nc(nc, "blob", "opaque", size=128)
+    inq_blob <- list(id=id_blob, name="blob", class="opaque", size=128)
+
+    id_vector <- type.def.nc(nc, "vector", "vlen", basetype="NC_FLOAT")
+    inq_vector <- list(id=id_vector, name="vector", class="vlen",
+                       size=16, basetype="NC_FLOAT")
+
+    id_factor <- type.def.nc(nc, "factor", "enum", basetype="NC_INT")
+    type.insert.nc(nc, "factor", "peanut butter", value=101)
+    type.insert.nc(nc, "factor", "jelly", value=102)
+    inq_factor <- list(id=id_factor, name="factor", class="enum",
+                       size=4, basetype="NC_INT",
+                       value=c("peanut butter"=101,"jelly"=102))
+
+    id_struct <- type.def.nc(nc, "struct", "compound", size=4+8+3*2)
+    type.insert.nc(nc, "struct", "siteid", offset=0, subtype="NC_INT")
+    type.insert.nc(nc, "struct", "height", offset=4, subtype="NC_DOUBLE")
+    type.insert.nc(nc, "struct", "colour", offset=12, subtype="NC_SHORT", dimsizes=c(3))
+    inq_struct <- list(id=id_struct, name="struct", class="compound", size=18,
+                       offset=c(siteid=0,height=4,colour=12),
+                       subtype=c(siteid="NC_INT",height="NC_DOUBLE",colour="NC_SHORT"),
+                       dimsizes=list("siteid"=NULL,"height"=NULL,"colour"=c(3)))
   }
 
   ##  Define variables
@@ -235,6 +260,10 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   } else {
     tally <- testfun(grpinfo$unlimids,3,tally)
   }
+  if (format == "netcdf4") {
+    cat("Inquire about user-defined types in file/group ...")
+    tally <- testfun(grpinfo$typeids,c(id_blob,id_vector,id_factor,id_struct),tally)
+  }
 
   cat("Read integer vector as double ... ")
   x <- mytime
@@ -339,6 +368,31 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
       y <- var.get.nc(nc, "stationid", fitnum=TRUE)
       tally <- testfun(x,y,tally)
     }
+
+    cat("Read details of user-defined types ...")
+    x <- inq_blob
+    y <- type.inq.nc(nc, id_blob)
+    tally <- testfun(x,y,tally)
+
+    x <- inq_vector
+    y <- type.inq.nc(nc, id_vector)
+    tally <- testfun(x,y,tally)
+
+    x <- inq_factor
+    y <- type.inq.nc(nc, id_factor)
+    tally <- testfun(x,y,tally)
+
+    x <- inq_factor[1:5]
+    y <- type.inq.nc(nc, id_factor, fields=FALSE)
+    tally <- testfun(x,y,tally)
+
+    x <- inq_struct
+    y <- type.inq.nc(nc, id_struct)
+    tally <- testfun(x,y,tally)
+
+    x <- inq_struct[1:4]
+    y <- type.inq.nc(nc, id_struct, fields=FALSE)
+    tally <- testfun(x,y,tally)
   }
 
   cat("Read and unpack numeric array ... ")


### PR DESCRIPTION
Add function `type.inq.nc` to get details of user-defined types, including the defined values of enumerated types and components of compound types.