### PR TITLE
Check function arguments in C

### DIFF
--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -484,7 +484,7 @@ var.get.nc <- function(ncfile, variable, start = NA, count = NA, na.mode = 4,
               rawchar, fitnum, na.mode, unpack)
   
   #-- Collapse singleton dimensions --------------------------------------
-  if (collapse && !is.null(dim(nc))) {
+  if (isTRUE(collapse) && !is.null(dim(nc))) {
     datadim <- dim(nc)
     keepdim <- (datadim != 1)
     if (any(keepdim)) {
@@ -599,7 +599,7 @@ var.put.nc <- function(ncfile, variable, data, start = NA, count = NA,
     } else {
       strlen <- 1
     }
-    if (max(nchar(data,type="bytes")) > strlen) {
+    if (isTRUE(max(nchar(data,type="bytes")) > strlen)) {
       warning(paste("Strings truncated to length",strlen), call.=FALSE)
     }
   }
@@ -727,7 +727,7 @@ grp.inq.nc <- function(ncid, grpname = NULL, ancestors = TRUE) {
   
   # Names of group:
   out$name <- .Call(R_nc_inq_grpname, ncid, FALSE)
-  if (ancestors) {
+  if (isTRUE(ancestors)) {
     out$fullname <- .Call(R_nc_inq_grpname, ncid, TRUE)
   }
   
@@ -784,7 +784,7 @@ read.nc <- function(ncfile, recursive = FALSE, ...) {
   #-- Initialise storage -----------------------------------------------------
   inq <- grp.inq.nc(ncfile)
   nvars <- length(inq$varids)
-  if (recursive) {
+  if (isTRUE(recursive)) {
     ngrps <- length(inq$grps)
     nelem <- nvars + ngrps
   } else {
@@ -825,17 +825,17 @@ type.def.nc <- function(ncfile, typename, class, size=NULL, basetype=NULL,
   stopifnot(class(ncfile) == "NetCDF")
   stopifnot(is.character(typename))
   stopifnot(is.character(class))
-  if (class == "compound") {
+  if (isTRUE(class == "compound")) {
     stopifnot(is.character(names))
     stopifnot(is.character(subtypes) || is.numeric(subtypes))
     stopifnot(is.list(dimsizes))
-  } else if (class == "enum") {
+  } else if (isTRUE(class == "enum")) {
     stopifnot(is.character(basetype) || is.numeric(basetype))
     stopifnot(is.character(names))
     stopifnot(is.numeric(values))
-  } else if (class == "opaque") {
+  } else if (isTRUE(class == "opaque")) {
     stopifnot(is.numeric(size))
-  } else if (class == "vlen") {
+  } else if (isTRUE(class == "vlen")) {
     stopifnot (is.character(basetype) || is.numeric(basetype))
   } else {
     stop("Unknown class for type definition", call.=FALSE)
@@ -881,17 +881,17 @@ utcal.nc <- function(unitstring, value, type = "n") {
   ut <- .Call(R_nc_calendar, unitstring, value)
   
   #-- Return object if no error ------------------------------------------
-  if (type == "n") {
+  if (isTRUE(type == "n")) {
     colnames(ut) <- c("year", "month", "day", "hour", "minute", "second")
     return(ut)
-  } else if (type == "s") {
+  } else if (isTRUE(type == "s")) {
     x <- apply(ut, 1, function(x) {
       paste(x[1], "-", sprintf("%02g", x[2]), "-", sprintf("%02g", 
         x[3]), " ", sprintf("%02g", x[4]), ":", sprintf("%02g", x[5]), 
         ":", sprintf("%02g", x[6]), sep = "")
     })
     return(x)
-  } else if (type == "c") {
+  } else if (isTRUE(type == "c")) {
     ct <- as.POSIXct(utinvcal.nc("seconds since 1970-01-01 00:00:00 +00:00", 
       ut), tz = "UTC", origin = ISOdatetime(1970, 1, 1, 0, 0, 0, tz = "UTC"))
     return(ct)
@@ -919,7 +919,7 @@ utinvcal.nc <- function(unitstring, value) {
   stopifnot(is.character(unitstring))
   
   if (is.character(value)) {
-    stopifnot(all(nchar(value) == 19))
+    stopifnot(isTRUE(all(nchar(value) == 19)))
     value <- cbind(substr(value, 1, 4), substr(value, 6, 7), substr(value, 
       9, 10), substr(value, 12, 13), substr(value, 15, 16), substr(value, 
       18, 19))

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -203,7 +203,6 @@ create.nc <- function(filename, clobber = TRUE, share = FALSE, prefill = TRUE,
   stopifnot(is.logical(prefill))
   stopifnot(is.character(format))
   stopifnot(is.logical(large))
-  stopifnot(nchar(filename) > 0L)
   
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_create, filename, clobber, share, prefill, format)
@@ -293,7 +292,6 @@ open.nc <- function(con, write = FALSE, share = FALSE, prefill = TRUE, ...) {
   stopifnot(is.logical(write))
   stopifnot(is.logical(share))
   stopifnot(is.logical(prefill))
-  stopifnot(nchar(con) > 0L)
   
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_open, con, write, share, prefill)

--- a/src/attribute.c
+++ b/src/attribute.c
@@ -66,7 +66,7 @@ R_nc_att_name (SEXP att, int ncid, int varid, char *attname)
 {
   if (isNumeric (att)) {
     return nc_inq_attname (ncid, varid, asInteger (att), attname);
-  } else if (isString (att)) {
+  } else if (isString (att) && xlength (att) > 0) {
     strncpy (attname, CHAR (STRING_ELT (att, 0)), NC_MAX_NAME);
     attname[NC_MAX_NAME] = '\0';
     return NC_NOERR;
@@ -259,7 +259,7 @@ R_nc_put_att (SEXP nc, SEXP var, SEXP att, SEXP type, SEXP data)
     R_nc_check (R_nc_var_id (var, ncid, &varid));
   }
 
-  attname = CHAR (STRING_ELT (att, 0));
+  attname = R_nc_strarg (att);
 
   R_nc_check (R_nc_type_id (type, ncid, &xtype, 0));
 
@@ -268,7 +268,7 @@ R_nc_put_att (SEXP nc, SEXP var, SEXP att, SEXP type, SEXP data)
 
   /*-- Write attribute to file ------------------------------------------------*/
   if (xtype == NC_CHAR && isString (data)) {
-    cnt = strlen (CHAR (STRING_ELT (data, 0)));
+    cnt = strlen (R_nc_strarg (data));
   } else {
     cnt = xlength (data);
   }
@@ -289,8 +289,7 @@ SEXP
 R_nc_rename_att (SEXP nc, SEXP var, SEXP att, SEXP newname)
 {
   int ncid, varid;
-  char attname[NC_MAX_NAME+1];
-  const char *newnamep;
+  const char *attname, *newattname;
 
   /*-- Convert arguments to netcdf ids ----------------------------------------*/
   ncid = asInteger (nc);
@@ -301,15 +300,15 @@ R_nc_rename_att (SEXP nc, SEXP var, SEXP att, SEXP newname)
     R_nc_check (R_nc_var_id (var, ncid, &varid));
   }
 
-  R_nc_check (R_nc_att_name (att, ncid, varid, attname));
+  attname = R_nc_strarg (att);
 
-  newnamep = CHAR (STRING_ELT (newname, 0));
+  newattname = R_nc_strarg (newname);
 
   /*-- Enter define mode ------------------------------------------------------*/
   R_nc_check( R_nc_redef (ncid));
 
   /*-- Rename the attribute ---------------------------------------------------*/
-  R_nc_check (nc_rename_att (ncid, varid, attname, newnamep));
+  R_nc_check (nc_rename_att (ncid, varid, attname, newattname));
 
   RRETURN(R_NilValue);
 }

--- a/src/common.c
+++ b/src/common.c
@@ -69,19 +69,11 @@ R_nc_unprotect (void)
 }
 
 
-#define R_NC_ERRLEN 8192
 void
-R_nc_error(const char *fmt, ...)
+R_nc_error(const char *msg)
 {
-  char buf[R_NC_ERRLEN];
-  va_list(ap);
-
-  va_start(ap, fmt);
-  vsnprintf(buf, R_NC_ERRLEN, fmt, ap);
-  va_end(ap);
- 
   R_nc_unprotect ();
-  error (buf);
+  error (msg);
 }
 
 

--- a/src/common.c
+++ b/src/common.c
@@ -318,6 +318,17 @@ R_nc_str2type (int ncid, const char *str, nc_type * xtype)
 }
 
 
+const char *
+R_nc_strarg (SEXP str)
+{
+  if (xlength (str) > 0 && isString (str)) {
+    return CHAR (STRING_ELT (str, 0));
+  } else {
+    RERROR ("Expected character string as argument");
+  }
+}
+
+
 int
 R_nc_redef (int ncid)
 {
@@ -336,5 +347,4 @@ R_nc_enddef (int ncid)
   nc_enddef(ncid);
   return NC_NOERR;
 }
-
 

--- a/src/common.c
+++ b/src/common.c
@@ -345,15 +345,19 @@ R_nc_sizearg (SEXP size)
     } else if (TYPEOF (size) == REALSXP) {
       if (R_nc_inherits (size, "integer64")) {
         long long llval;
-        unsigned long long ullval;
         llval = *(long long *) REAL (size);
         /* Allow wrapping of negative to positive values
            by converting from signed to unsigned long long
          */
-        ullval = llval;
-        erange = (ullval > SIZE_MAX || llval == NA_INTEGER64);
+        if (sizeof (long long) > sizeof (size_t)) {
+          erange = (llval < 0 || llval > SIZE_MAX || llval == NA_INTEGER64);
+        } else {
+          /* Allow wrapping of negative to positive values
+             in conversion from signed long long to (unsigned) size_t */
+          erange = (llval == NA_INTEGER64);
+        }
         if (!erange) {
-          result = ullval;
+          result = llval;
         }
       } else {
         double dval;

--- a/src/common.h
+++ b/src/common.h
@@ -36,6 +36,9 @@
 #ifndef RNC_COMMON_H_INCLUDED
 #define RNC_COMMON_H_INCLUDED
 
+#include <limits.h>
+#include <stdint.h>
+
 #ifndef NC_MAX_ATOMIC_TYPE
   #define NC_MAX_ATOMIC_TYPE NC_STRING
 #endif

--- a/src/common.h
+++ b/src/common.h
@@ -44,6 +44,12 @@
 
 #define RERROR(msg) { R_nc_error (msg); return NULL; }
 
+#define NA_SIZE SIZE_MAX
+
+/* Definition of missing value used by bit64 package */
+#define NA_INTEGER64 LLONG_MIN
+
+/* Common error strings */
 static const char RNC_EDATALEN[]="Not enough data", \
   RNC_EDATATYPE[]="Incompatible data for external type", \
   RNC_ETYPEDROP[]="Unsupported external type";
@@ -113,6 +119,13 @@ R_nc_str2type (int ncid, const char *str, nc_type * xtype);
  */
 const char *
 R_nc_strarg (SEXP str);
+
+
+/* Convert R numeric scalar argument to size_t.
+   Raise an error if R type or value is not compatible.
+ */
+size_t
+R_nc_sizearg (SEXP size);
 
 
 /* Enter netcdf define mode if possible.

--- a/src/common.h
+++ b/src/common.h
@@ -58,7 +58,7 @@ R_nc_unprotect (void);
 
 /* Raise an error in R */
 void
-R_nc_error(const char *fmt, ...);
+R_nc_error(const char *msg);
 
 /* If status is a netcdf error, raise an R error with a suitable message,
    otherwise return to caller. */

--- a/src/common.h
+++ b/src/common.h
@@ -107,6 +107,14 @@ R_nc_type2str (int ncid, nc_type xtype, char *str);
 int
 R_nc_str2type (int ncid, const char *str, nc_type * xtype);
 
+
+/* Extract C string from R character vector argument.
+   Raise an error if no string is found.
+ */
+const char *
+R_nc_strarg (SEXP str);
+
+
 /* Enter netcdf define mode if possible.
    Returns netcdf error code if an unhandled error occurs.
  */

--- a/src/convert.c
+++ b/src/convert.c
@@ -470,6 +470,11 @@ R_NC_R2C_NUM(R_nc_r2c_dbl_float, NC_DOUBLE, double, REAL, NC_FLOAT, float, \
 R_NC_R2C_NUM(R_nc_r2c_dbl_dbl, NC_DOUBLE, double, REAL, NC_DOUBLE, double, \
   R_NC_ISNA_REAL, R_NC_RANGE_NONE, , R_NC_RANGE_NONE, );
 
+/* bit64 is treated by R as signed long long,
+   but we may need to store unsigned long long,
+   with very large positive values wrapping to negative values in R.
+   We allow wrapping in reverse for conversion of bit64 to unsigned long long.
+ */
 R_NC_R2C_NUM(R_nc_r2c_bit64_schar, NC_INT64, long long, REAL, NC_BYTE, signed char, \
   R_NC_ISNA_BIT64, R_NC_RANGE_MIN, SCHAR_MIN, R_NC_RANGE_MAX, SCHAR_MAX);
 R_NC_R2C_NUM(R_nc_r2c_bit64_uchar, NC_INT64, long long, REAL, NC_UBYTE, unsigned char, \
@@ -484,12 +489,11 @@ R_NC_R2C_NUM(R_nc_r2c_bit64_uint, NC_INT64, long long, REAL, NC_UINT, unsigned i
   R_NC_ISNA_BIT64, R_NC_RANGE_MIN, 0, R_NC_RANGE_MAX, UINT_MAX);
 R_NC_R2C_NUM(R_nc_r2c_bit64_ll, NC_INT64, long long, REAL, NC_INT64, long long, \
   R_NC_ISNA_BIT64, R_NC_RANGE_NONE, , R_NC_RANGE_NONE, );
-/* Treat bit64 as unsigned when converting to unsigned long long */
-R_NC_R2C_NUM(R_nc_r2c_bit64_ull, NC_UINT64, unsigned long long, REAL, NC_UINT64, unsigned long long, \
+R_NC_R2C_NUM(R_nc_r2c_bit64_ull, NC_INT64, long long, REAL, NC_UINT64, unsigned long long, \
   R_NC_ISNA_BIT64, R_NC_RANGE_NONE, , R_NC_RANGE_NONE, );
-/* Assume bit64 and size_t are different types */
-R_NC_R2C_NUM(R_nc_r2c_bit64_size, NC_INT64, long long, REAL, NC_UINT64, size_t, \
-  R_NC_ISNA_BIT64, R_NC_RANGE_MIN, 0, R_NC_RANGE_MAX, SIZE_MAX);
+/* size_t may be smaller than unsigned long long (e.g. 32-bit platforms) */
+R_NC_R2C_NUM(R_nc_r2c_bit64_size, NC_INT64, long long, REAL, NC_NAT, size_t, \
+  R_NC_ISNA_BIT64, R_NC_RANGE_NONE, , R_NC_RANGE_MAX, SIZE_MAX);
 R_NC_R2C_NUM(R_nc_r2c_bit64_float, NC_INT64, long long, REAL, NC_FLOAT, float, \
   R_NC_ISNA_BIT64, R_NC_RANGE_MIN, -FLT_MAX, R_NC_RANGE_MAX, FLT_MAX);
 R_NC_R2C_NUM(R_nc_r2c_bit64_dbl, NC_INT64, long long, REAL, NC_DOUBLE, double, \
@@ -599,10 +603,13 @@ R_NC_C2R_NUM(R_nc_c2r_int64_dbl, NC_INT64, long long, NC_DOUBLE, double, \
 R_NC_C2R_NUM(R_nc_c2r_uint64_dbl, NC_UINT64, unsigned long long, NC_DOUBLE, double, \
   NA_REAL, 0, ULLONG_MAX);
 
+/* bit64 is treated by R as signed long long,
+   but we may need to store unsigned long long,
+   with very large positive values wrapping to negative values in R.
+ */
 R_NC_C2R_NUM(R_nc_c2r_int64_bit64, NC_INT64, long long, NC_INT64, long long, \
   NA_INTEGER64, LLONG_MIN, LLONG_MAX);
-/* Treat bit64 as unsigned when converting from unsigned long long */
-R_NC_C2R_NUM(R_nc_c2r_uint64_bit64, NC_UINT64, unsigned long long, NC_UINT64, unsigned long long, \
+R_NC_C2R_NUM(R_nc_c2r_uint64_bit64, NC_UINT64, unsigned long long, NC_INT64, long long, \
   NA_INTEGER64, 0, ULLONG_MAX);
 
 

--- a/src/convert.c
+++ b/src/convert.c
@@ -134,10 +134,17 @@ R_nc_length_sexp (SEXP count)
     for ( ii=0; ii<ndims; ii++ ) {
       length *= rcount[ii]; 
     }
+    if (!R_FINITE (length)) {
+      R_nc_error ("Non-finite length in R_nc_length_sexp");
+    }
   } else if (isInteger (count)) {
     icount = INTEGER (count);
     for ( ii=0; ii<ndims; ii++ ) {
-      length *= icount[ii]; 
+      if (icount[ii] != NA_INTEGER) {
+        length *= icount[ii];
+      } else {
+        R_nc_error ("Missing value in R_nc_length_sexp");
+      }
     }
   } else if (!isNull (count)) {
     R_nc_error ("Unsupported type in R_nc_length_sexp");

--- a/src/convert.c
+++ b/src/convert.c
@@ -487,14 +487,21 @@ R_NC_R2C_NUM(R_nc_r2c_bit64_ll, NC_INT64, long long, REAL, NC_INT64, long long, 
   R_NC_ISNA_BIT64, R_NC_RANGE_NONE, , R_NC_RANGE_NONE, );
 R_NC_R2C_NUM(R_nc_r2c_bit64_ull, NC_INT64, long long, REAL, NC_UINT64, unsigned long long, \
   R_NC_ISNA_BIT64, R_NC_RANGE_NONE, , R_NC_RANGE_NONE, );
-/* size_t may be smaller than unsigned long long (e.g. 32-bit platforms) */
-R_NC_R2C_NUM(R_nc_r2c_bit64_size, NC_INT64, long long, REAL, NC_NAT, size_t, \
-  R_NC_ISNA_BIT64, R_NC_RANGE_NONE, , R_NC_RANGE_MAX, SIZE_MAX);
 R_NC_R2C_NUM(R_nc_r2c_bit64_float, NC_INT64, long long, REAL, NC_FLOAT, float, \
   R_NC_ISNA_BIT64, R_NC_RANGE_MIN, -FLT_MAX, R_NC_RANGE_MAX, FLT_MAX);
 R_NC_R2C_NUM(R_nc_r2c_bit64_dbl, NC_INT64, long long, REAL, NC_DOUBLE, double, \
   R_NC_ISNA_BIT64, R_NC_RANGE_NONE, , R_NC_RANGE_NONE, );
-
+#if LLONG_MAX > SIZE_MAX
+/* size_t is smaller than unsigned long long.
+   Only allow positive values of bit64
+ */
+R_NC_R2C_NUM(R_nc_r2c_bit64_size, NC_INT64, long long, REAL, NC_NAT, size_t, \
+  R_NC_ISNA_BIT64, R_NC_RANGE_MIN, 0, R_NC_RANGE_MAX, SIZE_MAX);
+#else
+/* Allow wrapping from negative bit64 to positive size_t */
+R_NC_R2C_NUM(R_nc_r2c_bit64_size, NC_INT64, long long, REAL, NC_NAT, size_t, \
+  R_NC_ISNA_BIT64, R_NC_RANGE_NONE, , R_NC_RANGE_MAX, SIZE_MAX);
+#endif
 
 /* Allocate memory for reading a netcdf variable slice
    and converting the results to an R variable.

--- a/src/convert.c
+++ b/src/convert.c
@@ -1662,7 +1662,11 @@ FUN (SEXP rv, size_t N, TYPE fillval) \
 \
   /* Copy R elements to cv */ \
   if (isReal (rv)) { \
-    voidbuf = R_nc_r2c_dbl_##TYPENAME (rv, 1, &nr, &fillval, NULL, NULL); \
+    if (isInt64 (rv)) { \
+      voidbuf = R_nc_r2c_bit64_##TYPENAME (rv, 1, &nr, &fillval, NULL, NULL); \
+    } else { \
+      voidbuf = R_nc_r2c_dbl_##TYPENAME (rv, 1, &nr, &fillval, NULL, NULL); \
+    } \
   } else if (isInteger (rv)) { \
     voidbuf = R_nc_r2c_int_##TYPENAME (rv, 1, &nr, &fillval, NULL, NULL); \
   } else { \

--- a/src/convert.c
+++ b/src/convert.c
@@ -89,10 +89,6 @@ static const double ULLONG_MAX_DBL = \
 static const double SIZE_MAX_DBL = \
   ((double) SIZE_MAX) * (1.0 - DBL_EPSILON);
 
-/* Definitions for integer64 as provided by bit64 package */
-int isInt64(SEXP rv) {
-  return R_nc_inherits (rv, "integer64");
-}
 
 /*=============================================================================*\
  *  Memory management.
@@ -1283,7 +1279,7 @@ R_nc_r2c (SEXP rv, int ncid, nc_type xtype, int ndim, const size_t *xdim,
     }
     break;
   case REALSXP:  
-    if (isInt64(rv)) {
+    if (R_nc_inherits (rv, "integer64")) {
       switch (xtype) {
       case NC_BYTE:
 	return R_nc_r2c_bit64_schar (rv, ndim, xdim, fill, scale, add);
@@ -1669,7 +1665,7 @@ FUN (SEXP rv, size_t N, TYPE fillval) \
 \
   /* Copy R elements to cv */ \
   if (isReal (rv)) { \
-    if (isInt64 (rv)) { \
+    if (R_nc_inherits (rv, "integer64")) { \
       voidbuf = R_nc_r2c_bit64_##TYPENAME (rv, 1, &nr, &fillval, NULL, NULL); \
     } else { \
       voidbuf = R_nc_r2c_dbl_##TYPENAME (rv, 1, &nr, &fillval, NULL, NULL); \

--- a/src/convert.c
+++ b/src/convert.c
@@ -411,7 +411,7 @@ FUN (SEXP rv, int ndim, const size_t *xdim, \
   if ( erange ) { \
     R_nc_error (nc_strerror (NC_ERANGE)); \
   } else if ( efill ) { \
-    warning ("NA values sent to netcdf without conversion to fill value"); \
+    R_nc_error ("NA values sent to netcdf without conversion to fill value"); \
   } \
   return out; \
 }

--- a/src/convert.h
+++ b/src/convert.h
@@ -37,13 +37,6 @@
 #define RNC_CONVERT_H_INCLUDED
 
 
-#define NA_SIZE SIZE_MAX
-
-/* Definitions for integer64 as provided by bit64 package */
-#define NA_INTEGER64 LLONG_MIN
-int isInt64(SEXP rv);
-
-
 /* Find total number of elements in an array from dimension lengths.
    Result is 1 for a scalar or product of dimensions for an array.
    The special case ndims < 0 implies a vector of length count[0].

--- a/src/dataset.c
+++ b/src/dataset.c
@@ -93,6 +93,10 @@ R_nc_close (SEXP ptr)
 {
   int *fileid;
 
+  if (TYPEOF (ptr) != EXTPTRSXP) {
+    RERROR ("Not a valid NetCDF object");
+  }
+
   fileid = R_ExternalPtrAddr (ptr);
   if (!fileid) {
     RRETURN(R_NilValue);
@@ -124,6 +128,7 @@ R_nc_create (SEXP filename, SEXP clobber, SEXP share, SEXP prefill,
 {
   int cmode, fillmode, old_fillmode, ncid, *fileid;
   SEXP Rptr, result;
+  const char *filep;
 
   /*-- Determine the cmode ----------------------------------------------------*/
   if (asLogical(clobber) == TRUE) {
@@ -154,8 +159,12 @@ R_nc_create (SEXP filename, SEXP clobber, SEXP share, SEXP prefill,
   }
 
   /*-- Create the file --------------------------------------------------------*/
-  R_nc_check (nc_create (R_ExpandFileName (CHAR (STRING_ELT (filename, 0))),
-                       cmode, &ncid));
+  filep = R_nc_strarg (filename);
+  if (strlen (filep) > 0) {
+    R_nc_check (nc_create (R_ExpandFileName (filep), cmode, &ncid));
+  } else {
+    RERROR ("Filename must be a non-empty string");
+  }
   result = R_nc_protect (ScalarInteger (ncid));
 
   /*-- Arrange for file to be closed if handle is garbage collected -----------*/
@@ -214,6 +223,7 @@ SEXP
 R_nc_open (SEXP filename, SEXP write, SEXP share, SEXP prefill)
 {
   int ncid, omode, fillmode, old_fillmode, *fileid;
+  const char *filep;
   SEXP Rptr, result;
 
   /*-- Determine the omode ----------------------------------------------------*/
@@ -235,8 +245,12 @@ R_nc_open (SEXP filename, SEXP write, SEXP share, SEXP prefill)
   }
 
   /*-- Open the file ----------------------------------------------------------*/
-  R_nc_check (nc_open (R_ExpandFileName (CHAR (STRING_ELT (filename, 0))),
-                     omode, &ncid));
+  filep = R_nc_strarg (filename);
+  if (strlen (filep) > 0) {
+    R_nc_check (nc_open (R_ExpandFileName (filep), omode, &ncid));
+  } else {
+    RERROR ("Filename must be a non-empty string");
+  }
   result = R_nc_protect (ScalarInteger (ncid));
 
   /*-- Arrange for file to be closed if handle is garbage collected -----------*/

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -80,12 +80,7 @@ R_nc_def_dim (SEXP nc, SEXP dimname, SEXP size, SEXP unlim)
   if (asLogical(unlim) == TRUE) {
     nccnt = NC_UNLIMITED;
   } else {
-    /* Allow size to be a double, which can be larger than integer */
-    if (isInteger(size)) {
-      nccnt = asInteger(size);
-    } else {
-      nccnt = asReal(size);
-    }
+    nccnt = R_nc_sizearg (size);
   }
 
   R_nc_check (nc_def_dim (ncid, dimnamep, nccnt, &dimid));

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -71,7 +71,7 @@ R_nc_def_dim (SEXP nc, SEXP dimname, SEXP size, SEXP unlim)
   /*-- Convert arguments to netcdf ids ----------------------------------------*/
   ncid = asInteger (nc);
 
-  dimnamep = CHAR (STRING_ELT (dimname, 0));
+  dimnamep = R_nc_strarg (dimname);
 
   /*-- Enter define mode ------------------------------------------------------*/
   R_nc_check( R_nc_redef (ncid));
@@ -218,7 +218,7 @@ R_nc_rename_dim (SEXP nc, SEXP dim, SEXP newname)
 
   R_nc_check (R_nc_dim_id (dim, ncid, &dimid, 0));
 
-  newnamep = CHAR (STRING_ELT (newname, 0));
+  newnamep = R_nc_strarg (newname);
 
   /*-- Enter define mode ------------------------------------------------------*/
   R_nc_check( R_nc_redef (ncid));

--- a/src/group.c
+++ b/src/group.c
@@ -70,7 +70,7 @@ R_nc_def_grp (SEXP nc, SEXP grpname)
   /* Convert arguments to netcdf ids */
   ncid = asInteger (nc);
 
-  cgrpname = CHAR (STRING_ELT (grpname, 0));
+  cgrpname = R_nc_strarg (grpname);
 
   /* Enter define mode */
   R_nc_check( R_nc_redef (ncid));
@@ -159,7 +159,7 @@ R_nc_inq_grp_ncid (SEXP nc, SEXP grpname, SEXP full)
   SEXP result;
 
   ncid = asInteger (nc);
-  cgrpname = CHAR (STRING_ELT (grpname, 0));
+  cgrpname = R_nc_strarg (grpname);
 
   if (asLogical (full) == TRUE) {
     R_nc_check (nc_inq_grp_full_ncid (ncid, cgrpname, &grpid));
@@ -226,7 +226,7 @@ R_nc_rename_grp (SEXP nc, SEXP grpname)
   const char *cgrpname;
 
   ncid = asInteger (nc);
-  cgrpname = CHAR (STRING_ELT (grpname, 0));
+  cgrpname = R_nc_strarg (grpname);
 
   /* Enter define mode */
   R_nc_check( R_nc_redef (ncid));

--- a/src/type.c
+++ b/src/type.c
@@ -241,11 +241,7 @@ R_nc_def_type (SEXP nc, SEXP typename, SEXP class, SEXP size, SEXP basetype,
   } else if (R_nc_strcmp (class, "enum")) {
     typeid = R_nc_def_enum (ncid, typenamep, basetype, names, values);
   } else if (R_nc_strcmp (class, "opaque")) {
-    if (isInteger (size)) {
-      xsize = asInteger (size);
-    } else {
-      xsize = asReal (size);
-    }
+    xsize = R_nc_sizearg (size);
     R_nc_check (nc_def_opaque (ncid, xsize, typenamep, &typeid));
   } else if (R_nc_strcmp (class, "vlen")) {
     R_nc_check (R_nc_type_id (basetype, ncid, &xtype, 0));
@@ -292,12 +288,7 @@ R_nc_insert_type (SEXP nc, SEXP type, SEXP name, SEXP value,
   } else if (class == NC_COMPOUND) {
     if (!isNull (offset) && !isNull (subtype)) {
 
-      if (isInteger (offset)) {
-        coffset = asInteger (offset);
-      } else {
-        /* offset could be larger than integer */
-        coffset = asReal (offset);
-      }
+      coffset = R_nc_sizearg (offset);
 
       R_nc_check (R_nc_type_id (subtype, ncid, &xtype, 0));
       R_nc_check (nc_inq_type (ncid, xtype, NULL, &subsize));

--- a/src/type.c
+++ b/src/type.c
@@ -230,7 +230,7 @@ R_nc_def_type (SEXP nc, SEXP typename, SEXP class, SEXP size, SEXP basetype,
   /*-- Decode arguments -------------------------------------------------------*/
   ncid = asInteger (nc);
 
-  typenamep = CHAR (STRING_ELT (typename, 0));
+  typenamep = R_nc_strarg (typename);
 
   /*-- Enter define mode ------------------------------------------------------*/
   R_nc_check( R_nc_redef (ncid));
@@ -279,7 +279,7 @@ R_nc_insert_type (SEXP nc, SEXP type, SEXP name, SEXP value,
 
   R_nc_check (R_nc_type_id (type, ncid, &typeid, 0));
 
-  fldname = CHAR (STRING_ELT (name, 0));
+  fldname = R_nc_strarg (name);
 
   R_nc_check (nc_inq_user_type (ncid, typeid, NULL, &xsize, &xtype, NULL, &class));
 

--- a/src/udunits.c
+++ b/src/udunits.c
@@ -111,7 +111,7 @@ R_nc_calendar (SEXP unitstring, SEXP values)
   SEXP result;
 
   /* Handle arguments and initialise outputs */
-  cstring = CHAR (STRING_ELT (unitstring, 0));
+  cstring = R_nc_strarg (unitstring);
   isreal = isReal (values);
   if (isreal) {
     dvals = REAL (values);
@@ -193,6 +193,7 @@ SEXP
 R_nc_utinit (SEXP path)
 {
   int status;
+  const char *pathp;
 
   /*-- Terminate library if loaded previously ---------------------------------*/
 #ifdef HAVE_UTISINIT
@@ -207,7 +208,8 @@ R_nc_utinit (SEXP path)
 #endif
 
   /*-- Initialize udunits library ---------------------------------------------*/
-  status = utInit (R_ExpandFileName (CHAR (STRING_ELT (path, 0))));
+  pathp = R_nc_strarg (path);
+  status = utInit (R_ExpandFileName (pathp));
 
   /*-- Avoid "overriding default" messages from UDUNITS-2 (2/2) ---------------*/
 #ifdef HAVE_LIBUDUNITS2
@@ -239,7 +241,7 @@ R_nc_inv_calendar (SEXP unitstring, SEXP values)
   SEXP result;
 
   /* Handle arguments and initialise outputs */
-  cstring = CHAR (STRING_ELT (unitstring, 0));
+  cstring = R_nc_strarg (unitstring);
   isreal = isReal (values);
   if (isreal) {
     dvals = REAL (values);

--- a/src/variable.c
+++ b/src/variable.c
@@ -72,7 +72,7 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims)
   /*-- Convert arguments to netcdf ids ----------------------------------------*/
   ncid = asInteger (nc);
 
-  varnamep = CHAR (STRING_ELT (varname, 0));
+  varnamep = R_nc_strarg (varname);
 
   R_nc_check (R_nc_type_id (type, ncid, &xtype, 0));
 
@@ -552,7 +552,7 @@ R_nc_rename_var (SEXP nc, SEXP var, SEXP newname)
 
   R_nc_check (R_nc_var_id (var, ncid, &varid));
 
-  cnewname = CHAR (STRING_ELT (newname, 0));
+  cnewname = R_nc_strarg (newname);
 
   /*-- Enter define mode ------------------------------------------------------*/
   R_nc_check( R_nc_redef (ncid));

--- a/src/variable.c
+++ b/src/variable.c
@@ -212,9 +212,11 @@ R_nc_miss_att (int ncid, int varid, int mode,
         *min = range;
         *max = range + 1;
         if (xtype == NC_UBYTE) {
-          R_nc_check (nc_get_att_uchar (ncid, varid, "valid_range", range));
+          R_nc_check (nc_get_att_uchar (
+                        ncid, varid, "valid_range", (unsigned char *) range));
         } else {
-          R_nc_check (nc_get_att_schar (ncid, varid, "valid_range", range));
+          R_nc_check (nc_get_att_schar (
+                        ncid, varid, "valid_range", (signed char *) range));
         }
       }
 


### PR DESCRIPTION
Closes #42 

Extra argument checks have been added to C functions called by R. These should avoid unexpected behaviour caused by incorrect data types, out-of-range type conversions or missing values.