### PR TITLE
Find netcdf header files in non-standard locations 

### DIFF
--- a/configure
+++ b/configure
@@ -2077,6 +2077,10 @@ fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
 CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
 
+# Prepend user-specified CPPFLAGS to those from R:
+R_CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
+CPPFLAGS="$CPPFLAGS $R_CPPFLAGS"
+
 #-------------------------------------------------------------------------------#
 #  Find NetCDF library and header files                                         #
 #-------------------------------------------------------------------------------#

--- a/configure
+++ b/configure
@@ -626,7 +626,6 @@ UDUNITS_LIB
 EGREP
 GREP
 CPP
-have_nc_config
 OBJEXT
 EXEEXT
 ac_ct_CC
@@ -634,6 +633,7 @@ CPPFLAGS
 LDFLAGS
 CFLAGS
 CC
+have_nc_config
 target_alias
 host_alias
 build_alias
@@ -2066,7 +2066,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
 #-------------------------------------------------------------------------------#
-#  Find the compiler and compiler options to use   	                 	#
+#  Find the compiler and compiler options to use for tests                   	#
 #-------------------------------------------------------------------------------#
 
 : ${R_HOME=`R RHOME`}
@@ -2076,10 +2076,83 @@ if test -z "${R_HOME}"; then
 fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
 CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
-R_CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
-CPPFLAGS="$CPPFLAGS $R_CPPFLAGS"
 
-# Define a suitable value for the "restrict" keyword:
+#-------------------------------------------------------------------------------#
+#  Find NetCDF library and header files                                         #
+#-------------------------------------------------------------------------------#
+
+
+# Check whether --with-nc-config was given.
+if test "${with_nc_config+set}" = set; then :
+  withval=$with_nc_config;
+else
+  with_nc_config=yes
+fi
+
+
+if test "x$with_nc_config" != xno; then :
+  # Extract the first word of "nc-config", so it can be a program name with args.
+set dummy nc-config; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_have_nc_config+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -n "$have_nc_config"; then
+  ac_cv_prog_have_nc_config="$have_nc_config" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_prog_have_nc_config="yes"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  test -z "$ac_cv_prog_have_nc_config" && ac_cv_prog_have_nc_config="no"
+fi
+fi
+have_nc_config=$ac_cv_prog_have_nc_config
+if test -n "$have_nc_config"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_nc_config" >&5
+$as_echo "$have_nc_config" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+
+fi
+
+if test "x$have_nc_config" == xyes; then :
+
+    # Prepend linker flags to LDFLAGS:
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking netcdf linker flags" >&5
+$as_echo_n "checking netcdf linker flags... " >&6; }
+    NETCDF_LIBS=`nc-config --libs`
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $NETCDF_LIBS" >&5
+$as_echo "$NETCDF_LIBS" >&6; }
+    LDFLAGS="$NETCDF_LIBS $LDFLAGS"
+    # Prepend preprocessor and compiler flags to CPPFLAGS:
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking netcdf preprocessor and compiler flags" >&5
+$as_echo_n "checking netcdf preprocessor and compiler flags... " >&6; }
+    NETCDF_CFLAGS=`nc-config --cflags`
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $NETCDF_CFLAGS" >&5
+$as_echo "$NETCDF_CFLAGS" >&6; }
+    CPPFLAGS="$NETCDF_CFLAGS $CPPFLAGS"
+
+
+fi
+
+# Check that netcdf header files can be compiled:
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -2870,108 +2943,6 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for C/C++ restrict keyword" >&5
-$as_echo_n "checking for C/C++ restrict keyword... " >&6; }
-if ${ac_cv_c_restrict+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  ac_cv_c_restrict=no
-   # The order here caters to the fact that C++ does not require restrict.
-   for ac_kw in __restrict __restrict__ _Restrict restrict; do
-     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-typedef int * int_ptr;
-	int foo (int_ptr $ac_kw ip) {
-	return ip[0];
-       }
-int
-main ()
-{
-int s[1];
-	int * $ac_kw t = s;
-	t[0] = 0;
-	return foo(t)
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  ac_cv_c_restrict=$ac_kw
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-     test "$ac_cv_c_restrict" != no && break
-   done
-
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_restrict" >&5
-$as_echo "$ac_cv_c_restrict" >&6; }
-
- case $ac_cv_c_restrict in
-   restrict) ;;
-   no) $as_echo "#define restrict /**/" >>confdefs.h
- ;;
-   *)  cat >>confdefs.h <<_ACEOF
-#define restrict $ac_cv_c_restrict
-_ACEOF
- ;;
- esac
-
-
-#-------------------------------------------------------------------------------#
-#  Find NetCDF library and header files                                         #
-#-------------------------------------------------------------------------------#
-
-
-# Check whether --with-nc-config was given.
-if test "${with_nc_config+set}" = set; then :
-  withval=$with_nc_config;
-else
-  with_nc_config=yes
-fi
-
-
-if test "x$with_nc_config" != xno; then :
-  # Extract the first word of "nc-config", so it can be a program name with args.
-set dummy nc-config; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_have_nc_config+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -n "$have_nc_config"; then
-  ac_cv_prog_have_nc_config="$have_nc_config" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_have_nc_config="yes"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  test -z "$ac_cv_prog_have_nc_config" && ac_cv_prog_have_nc_config="no"
-fi
-fi
-have_nc_config=$ac_cv_prog_have_nc_config
-if test -n "$have_nc_config"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $have_nc_config" >&5
-$as_echo "$have_nc_config" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-
-fi
-
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -3369,26 +3340,7 @@ fi
 done
 
 
-if test "x$have_nc_config" == xyes; then :
-
-    # Find libraries and cflags used to build netcdf:
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking netcdf linker flags" >&5
-$as_echo_n "checking netcdf linker flags... " >&6; }
-    NETCDF_LIBS=`nc-config --libs`
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $NETCDF_LIBS" >&5
-$as_echo "$NETCDF_LIBS" >&6; }
-    LDFLAGS="$NETCDF_LIBS $LDFLAGS"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking netcdf compiler flags" >&5
-$as_echo_n "checking netcdf compiler flags... " >&6; }
-    NETCDF_CFLAGS=`nc-config --cflags`
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $NETCDF_CFLAGS" >&5
-$as_echo "$NETCDF_CFLAGS" >&6; }
-    CFLAGS="$NETCDF_CFLAGS $CFLAGS"
-
-else
-
-    # Check that netcdf header files can be compiled:
-    for ac_header in netcdf.h
+for ac_header in netcdf.h
 do :
   ac_fn_c_check_header_mongrel "$LINENO" "netcdf.h" "ac_cv_header_netcdf_h" "$ac_includes_default"
 if test "x$ac_cv_header_netcdf_h" = xyes; then :
@@ -3402,8 +3354,10 @@ fi
 
 done
 
-    # Add netcdf library to LIBS if it can be linked (and is not already being linked):
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing nc_open" >&5
+
+# Check that netcdf library can be found.
+# Linker flags are prepended to LIBS if needed.
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing nc_open" >&5
 $as_echo_n "checking for library containing nc_open... " >&6; }
 if ${ac_cv_search_nc_open+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -3461,9 +3415,6 @@ else
   as_fn_error $? "\"netcdf library was not linked - defining LDFLAGS may help\"" "$LINENO" 5
 fi
 
-
-
-fi
 
 # Check for the existence of optional netcdf routines.
 # Afterwards, C preprocessor macros HAVE_DECL_symbols are defined,

--- a/configure.ac
+++ b/configure.ac
@@ -16,9 +16,6 @@ fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
 CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
 
-# Define a suitable value for the "restrict" keyword:
-AC_C_RESTRICT()
-
 #-------------------------------------------------------------------------------#
 #  Find NetCDF library and header files                                         #
 #-------------------------------------------------------------------------------#

--- a/configure.ac
+++ b/configure.ac
@@ -32,15 +32,16 @@ AS_IF([test "x$with_nc_config" != xno],
 
 AS_IF([test "x$have_nc_config" == xyes],
   [
-    # Find libraries and cflags used to build netcdf:
+    # Prepend linker flags to LDFLAGS:
     AC_MSG_CHECKING(netcdf linker flags)
     NETCDF_LIBS=`nc-config --libs`
     AC_MSG_RESULT($NETCDF_LIBS)
     LDFLAGS="$NETCDF_LIBS $LDFLAGS"
-    AC_MSG_CHECKING(netcdf compiler flags)
+    # Prepend preprocessor and compiler flags to CPPFLAGS:
+    AC_MSG_CHECKING(netcdf preprocessor and compiler flags)
     NETCDF_CFLAGS=`nc-config --cflags`
     AC_MSG_RESULT($NETCDF_CFLAGS)
-    CFLAGS="$NETCDF_CFLAGS $CFLAGS"
+    CPPFLAGS="$NETCDF_CFLAGS $CPPFLAGS"
   ], [
     # Check that netcdf header files can be compiled:
     AC_CHECK_HEADERS(netcdf.h, [],

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 AC_INIT([RNetCDF], [2.0-1])
 
 #-------------------------------------------------------------------------------#
-#  Find the compiler and compiler options to use   	                 	#
+#  Find the compiler and compiler options to use for tests                   	#
 #-------------------------------------------------------------------------------#
 
 : ${R_HOME=`R RHOME`}
@@ -15,8 +15,6 @@ if test -z "${R_HOME}"; then
 fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
 CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
-R_CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
-CPPFLAGS="$CPPFLAGS $R_CPPFLAGS"
 
 # Define a suitable value for the "restrict" keyword:
 AC_C_RESTRICT()

--- a/configure.ac
+++ b/configure.ac
@@ -16,6 +16,10 @@ fi
 CC=`"${R_HOME}/bin/R" CMD config CC`
 CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS`
 
+# Prepend user-specified CPPFLAGS to those from R:
+R_CPPFLAGS=`"${R_HOME}/bin/R" CMD config CPPFLAGS`
+CPPFLAGS="$CPPFLAGS $R_CPPFLAGS"
+
 #-------------------------------------------------------------------------------#
 #  Find NetCDF library and header files                                         #
 #-------------------------------------------------------------------------------#

--- a/configure.ac
+++ b/configure.ac
@@ -42,15 +42,17 @@ AS_IF([test "x$have_nc_config" == xyes],
     NETCDF_CFLAGS=`nc-config --cflags`
     AC_MSG_RESULT($NETCDF_CFLAGS)
     CPPFLAGS="$NETCDF_CFLAGS $CPPFLAGS"
-  ], [
-    # Check that netcdf header files can be compiled:
-    AC_CHECK_HEADERS(netcdf.h, [],
-       AC_MSG_ERROR("netcdf.h was not compiled - defining CPPFLAGS may help"))
-    # Add netcdf library to LIBS if it can be linked (and is not already being linked):
-    AC_SEARCH_LIBS(nc_open, netcdf, [],
-        AC_MSG_ERROR("netcdf library was not linked - defining LDFLAGS may help"))
   ]
 )
+
+# Check that netcdf header files can be compiled:
+AC_CHECK_HEADERS(netcdf.h, [],
+    AC_MSG_ERROR("netcdf.h was not compiled - defining CPPFLAGS may help"))
+
+# Check that netcdf library can be found.
+# Linker flags are prepended to LIBS if needed.
+AC_SEARCH_LIBS(nc_open, netcdf, [],
+    AC_MSG_ERROR("netcdf library was not linked - defining LDFLAGS may help"))
 
 # Check for the existence of optional netcdf routines.
 # Afterwards, C preprocessor macros HAVE_DECL_symbols are defined,


### PR DESCRIPTION
Resolves #48 .

Installation of RNetCDF from source code was failing in the R for Mac GUI. The netcdf library was installed as part of Fink, but similar problems would probably occur with other package managers or custom installations.

The causes of the problem were found to be:

1. R for Mac GUI starts with a minimal PATH, so that `nc-config` is not found. This can be fixed by using `Sys.setenv` to modify PATH inside an R session, or by launching the R GUI from a terminal after defining PATH as required.

2. The `configure` script was not adding preprocessor flags from `nc-config` to CPPFLAGS, so the compiler was not searching for header files in the correct directories.

Item 1 may only be a problem on Mac, and it is not caused by RNetCDF itself. 

This PR fixes item 2, which could affect any platforms with netcdf installed in non-standard locations.