### PR TITLE
Show user defined types and attributes in print.nc

### DIFF
--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -81,9 +81,13 @@ att.get.nc <- function(ncfile, variable, attribute,
   stopifnot(is.character(attribute) || is.numeric(attribute))
   stopifnot(is.logical(rawchar))
   stopifnot(is.logical(fitnum))
-  
+
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_get_att, ncfile, variable, attribute, rawchar, fitnum)
+
+  if (inherits(nc, "integer64")) {
+    require(bit64)
+  }
 
   return(nc)
 }
@@ -517,6 +521,10 @@ var.get.nc <- function(ncfile, variable, start = NA, count = NA, na.mode = 4,
     if (any(keepdim)) {
       dim(nc) <- datadim[keepdim]
     }
+  }
+
+  if (inherits(nc, "integer64")) {
+    require(bit64)
   }
  
   return(nc)

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -322,13 +322,14 @@ print_grp <- function(x, level = 0) {
       if (varinfo$natts != 0) {
         for (jj in 0:(varinfo$natts - 1)) {
           attinfo <- att.inq.nc(x, id, jj)
-          cat(indent, rep(" ", 16), varinfo$name, ":", attinfo$name, 
-          sep = "")
-          if (attinfo$type == "NC_CHAR") {
-          cat(" = \"", att.get.nc(x, id, jj), "\" ;\n", sep = "")
+          if (attinfo$type == "NC_CHAR" || attinfo$type == "NC_STRING") {
+            attvalstr <- paste("\"", att.get.nc(x, id, jj), "\"", 
+                               collapse=", ", sep="")
           } else {
-          cat(" = ", att.get.nc(x, id, jj), " ;\n", sep = "")
+            attvalstr <- paste(att.get.nc(x, id, jj), collapse=", ", sep="")
           }
+          cat(indent, rep(" ", 16), varinfo$name, ":", attinfo$name,
+              " = ", attvalstr, " ;\n", sep="")
         }
       }
     }
@@ -340,15 +341,17 @@ print_grp <- function(x, level = 0) {
     id <- "NC_GLOBAL"
     for (jj in 0:(grpinfo$ngatts - 1)) {
       attinfo <- att.inq.nc(x, id, jj)
-      cat(indent, rep(" ", 16), ":", attinfo$name, sep = "")
-      if (attinfo$type == "NC_CHAR") {
-        cat(" = \"", att.get.nc(x, id, jj), "\" ;\n", sep = "")
+      if (attinfo$type == "NC_CHAR" || attinfo$type == "NC_STRING") {
+        attvalstr <- paste("\"", att.get.nc(x, id, jj), "\"", 
+                           collapse=", ", sep="")
       } else {
-        cat(" = ", att.get.nc(x, id, jj), " ;\n", sep = "")
+        attvalstr <- paste(att.get.nc(x, id, jj), collapse=", ", sep="")
       }
+      cat(indent, rep(" ", 16), ":", attinfo$name,
+          " = ", attvalstr, " ;\n", sep="")
     }
   }
-  
+
   #-- Print groups recursively -----------------------------------------------
   if (length(grpinfo$grps) != 0) {
     for (id in grpinfo$grps) {

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -300,7 +300,7 @@ print_att <- function(grp, attinfo, indent, varinfo=NULL) {
     attvalstr <- "..."
   } else {
     atttypestr <- attinfo$type
-    attvalstr <- paste(att.get.nc(grp, varid, attinfo$id),
+    attvalstr <- paste(att.get.nc(grp, varid, attinfo$id, fitnum=TRUE),
                        collapse=", ", sep="")
   }
   cat(indent, rep(" ", 16), atttypestr, " ",

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -117,8 +117,9 @@ att.put.nc <- function(ncfile, variable, name, type, value) {
   stopifnot(is.character(variable) || is.numeric(variable))
   stopifnot(is.character(name))
   stopifnot(is.character(type) || is.numeric(type))
-  stopifnot(is.numeric(value) || is.character(value) ||
-            is.raw(value) || is.logical(value))
+  stopifnot(is.numeric(value) || is.character(value) || is.raw(value) ||
+            is.logical(value) || is.list(value) || is.factor(value))
+
   
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_put_att, ncfile, variable, name, type, value)

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -428,9 +428,13 @@ print_grp <- function(x, level = 0) {
 print.nc <- function(x, ...) {
   #-- Check args -------------------------------------------------------------
   stopifnot(class(x) == "NetCDF")
-  
+
+  cat("netcdf ", file.inq.nc(x)$format, " {\n", sep="")
+
   # Display groups recursively:
   print_grp(x, level = 0)
+
+  cat("}\n")
 
   return(invisible(NULL))
 }

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -85,6 +85,11 @@ att.get.nc <- function(ncfile, variable, attribute,
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_get_att, ncfile, variable, attribute, rawchar, fitnum)
 
+  if (inherits(nc, "integer64") &&
+      !requireNamespace("bit64", quietly=TRUE)) {
+    stop("Package 'bit64' required for class 'integer64'")
+  }
+
   return(nc)
 }
 
@@ -527,7 +532,12 @@ var.get.nc <- function(ncfile, variable, start = NA, count = NA, na.mode = 4,
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_get_var, ncfile, variable, start, count,
               rawchar, fitnum, na.mode, unpack)
-  
+
+  if (inherits(nc, "integer64") &&
+      !requireNamespace("bit64", quietly=TRUE)) {
+    stop("Package 'bit64' required for class 'integer64'")
+  }
+
   #-- Collapse singleton dimensions --------------------------------------
   if (isTRUE(collapse) && !is.null(dim(nc))) {
     datadim <- dim(nc)

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -301,6 +301,45 @@ print_grp <- function(x, level = 0) {
     }
   }
   
+  #-- Inquire about all types ------------------------------------------------
+  if (length(grpinfo$typeids) != 0) {
+    cat(indent, "types:\n", sep = "")
+    for (id in grpinfo$typeids) {
+      typeinfo <- type.inq.nc(x, id, fields=TRUE)
+      if (typeinfo$class == "compound") {
+        cat(indent, indent, "compound ", typeinfo$name, " {\n", sep="")
+        field_names = names(typeinfo$subtype)
+        field_types = unname(typeinfo$subtype)
+        field_sizes = unname(typeinfo$dimsizes)
+        for (item in seq_along(typeinfo$subtype)) {
+          cat(indent, indent, indent, field_types[item], " ",
+              field_names[item], sep="")
+          if (!is.null(field_sizes[[item]])) {
+            cat("(", paste(field_sizes[[item]], collapse=","), ")", sep="")
+          }
+          cat(" ;\n")
+        }
+        cat(indent, indent, "}; // ", typeinfo$name, "\n", sep="")
+      } else if (typeinfo$class == "enum") {
+        cat(indent, indent, typeinfo$basetype, " enum ", typeinfo$name,
+            " {\n", sep="")
+        member_names <- names(typeinfo$value)
+        member_values <- unname(typeinfo$value)
+        for (item in seq_along(typeinfo$value)) {
+          cat(indent, indent, indent, member_names[item],
+              " = ", member_values[item], ",\n", sep="")
+        }
+        cat(indent, indent, "} ; // ", typeinfo$name, "\n", sep="")
+      } else if (typeinfo$class == "opaque") {
+        cat(indent, indent, "opaque(", typeinfo$size, ") ", typeinfo$name,
+            " ;\n", sep="")
+      } else if (typeinfo$class == "vlen") {
+        cat(indent, indent, typeinfo$basetype, "(*) ", typeinfo$name,
+            " ;\n", sep="")
+      }
+    }
+  }
+
   #-- Inquire about all variables --------------------------------------------
   if (length(grpinfo$varids) != 0) {
     cat(indent, "variables:\n", sep = "")

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -276,6 +276,34 @@ open.nc <- function(con, write = FALSE, share = FALSE, prefill = TRUE, ...) {
 # print.nc()
 #-------------------------------------------------------------------------------
 
+# Private function to print attributes,
+# given results from var.inq.nc and att.inq.nc:
+print_att <- function(grp, attinfo, indent, varinfo=NULL) {
+  if (is.null(varinfo)) {
+    varid <- "NC_GLOBAL"
+    varname <- ""
+  } else {
+    varid <- varinfo$id
+    varname <- varinfo$name
+  }
+  typeinfo <- type.inq.nc(grp, attinfo$type, fields=FALSE)
+  if (attinfo$type == "NC_CHAR" || attinfo$type == "NC_STRING") {
+    atttypestr <- attinfo$type
+    attvalstr <- paste("\"", att.get.nc(grp, varid, attinfo$id), "\"", 
+		       collapse=", ", sep="")
+  } else if (typeinfo$class != "builtin") {
+    atttypestr <- paste("//", attinfo$type, sep="");
+    attvalstr <- "..."
+  } else {
+    atttypestr <- attinfo$type
+    attvalstr <- paste(att.get.nc(grp, varid, attinfo$id),
+                       collapse=", ", sep="")
+  }
+  cat(indent, rep(" ", 16), atttypestr, " ",
+      varname, ":", attinfo$name,
+      " = ", attvalstr, " ;\n", sep="")
+}
+
 # Private function to print metadata of groups recursively:
 print_grp <- function(x, level = 0) {
   
@@ -362,14 +390,7 @@ print_grp <- function(x, level = 0) {
       if (varinfo$natts != 0) {
         for (jj in 0:(varinfo$natts - 1)) {
           attinfo <- att.inq.nc(x, id, jj)
-          if (attinfo$type == "NC_CHAR" || attinfo$type == "NC_STRING") {
-            attvalstr <- paste("\"", att.get.nc(x, id, jj), "\"", 
-                               collapse=", ", sep="")
-          } else {
-            attvalstr <- paste(att.get.nc(x, id, jj), collapse=", ", sep="")
-          }
-          cat(indent, rep(" ", 16), varinfo$name, ":", attinfo$name,
-              " = ", attvalstr, " ;\n", sep="")
+          print_att(x, attinfo, indent, varinfo)
         }
       }
     }
@@ -381,14 +402,7 @@ print_grp <- function(x, level = 0) {
     id <- "NC_GLOBAL"
     for (jj in 0:(grpinfo$ngatts - 1)) {
       attinfo <- att.inq.nc(x, id, jj)
-      if (attinfo$type == "NC_CHAR" || attinfo$type == "NC_STRING") {
-        attvalstr <- paste("\"", att.get.nc(x, id, jj), "\"", 
-                           collapse=", ", sep="")
-      } else {
-        attvalstr <- paste(att.get.nc(x, id, jj), collapse=", ", sep="")
-      }
-      cat(indent, rep(" ", 16), ":", attinfo$name,
-          " = ", attvalstr, " ;\n", sep="")
+      print_att(x, attinfo, indent)
     }
   }
 

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -306,7 +306,7 @@ print_grp <- function(x, level = 0) {
     cat(indent, "variables:\n", sep = "")
     for (id in grpinfo$varids) {
       varinfo <- var.inq.nc(x, id)
-      vartype <- substring(tolower(varinfo$type), 4)
+      vartype <- varinfo$type
       cat(indent, "        ", vartype, " ", varinfo$name, sep = "")
       if (varinfo$ndims > 0) {
         cat("(")

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -402,7 +402,11 @@ print_grp <- function(x, level = 0) {
   
   #-- Inquire about global attributes ----------------------------------------
   if (grpinfo$ngatts != 0) {
-    cat("\n", indent, "// global attributes:\n", sep = "")
+    if (level == 0) {
+      cat("\n", indent, "// global attributes:\n", sep = "")
+    } else {
+      cat("\n", indent, "// group attributes:\n", sep = "")
+    }
     id <- "NC_GLOBAL"
     for (jj in 0:(grpinfo$ngatts - 1)) {
       attinfo <- att.inq.nc(x, id, jj)

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -85,10 +85,6 @@ att.get.nc <- function(ncfile, variable, attribute,
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_get_att, ncfile, variable, attribute, rawchar, fitnum)
 
-  if (inherits(nc, "integer64")) {
-    require(bit64)
-  }
-
   return(nc)
 }
 
@@ -300,8 +296,14 @@ print_att <- function(grp, attinfo, indent, varinfo=NULL) {
     attvalstr <- "..."
   } else {
     atttypestr <- attinfo$type
-    attvalstr <- paste(att.get.nc(grp, varid, attinfo$id, fitnum=TRUE),
-                       collapse=", ", sep="")
+    attval <- att.get.nc(grp, varid, attinfo$id,
+                         fitnum=requireNamespace("bit64", quietly=TRUE))
+    if (inherits(attval, "integer64")) {
+      attvalchar <- bit64::as.character.integer64(attval)
+    } else {
+      attvalchar <- as.character(attval)
+    }
+    attvalstr <- paste(attvalchar, collapse=", ", sep="")
   }
   tab <- "\t"
   cat(indent, tab, tab, atttypestr, " ",
@@ -535,10 +537,6 @@ var.get.nc <- function(ncfile, variable, start = NA, count = NA, na.mode = 4,
     }
   }
 
-  if (inherits(nc, "integer64")) {
-    require(bit64)
-  }
- 
   return(nc)
 }
 

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -303,16 +303,19 @@ print_att <- function(grp, attinfo, indent, varinfo=NULL) {
     attvalstr <- paste(att.get.nc(grp, varid, attinfo$id, fitnum=TRUE),
                        collapse=", ", sep="")
   }
-  cat(indent, rep(" ", 16), atttypestr, " ",
+  tab <- "\t"
+  cat(indent, tab, tab, atttypestr, " ",
       varname, ":", attinfo$name,
       " = ", attvalstr, " ;\n", sep="")
 }
 
 # Private function to print metadata of groups recursively:
 print_grp <- function(x, level = 0) {
-  
-  indent <- paste(rep("  ", level), collapse = "")
-  
+
+  gap <- "  "
+  indent <- paste(rep(gap, level), collapse = "")
+  tab <- "\t"
+
   #-- Inquire about the group ------------------------------------------------
   grpinfo <- try(grp.inq.nc(x, ancestors = FALSE), silent = TRUE)
   if (class(grpinfo) == "try-error" || is.null(grpinfo)) {
@@ -325,10 +328,10 @@ print_grp <- function(x, level = 0) {
     for (id in grpinfo$dimids) {
       diminfo <- dim.inq.nc(x, id)
       if (diminfo$unlim == FALSE) {
-        cat(indent, "        ", diminfo$name, " = ", diminfo$length, 
+        cat(indent, tab, diminfo$name, " = ", diminfo$length,
           " ;\n", sep = "")
       } else {
-        cat(indent, "        ", diminfo$name, " = UNLIMITED ; // (", 
+        cat(indent, tab, diminfo$name, " = UNLIMITED ; // (",
           diminfo$length, " currently)\n", sep = "")
       }
     }
@@ -340,34 +343,34 @@ print_grp <- function(x, level = 0) {
     for (id in grpinfo$typeids) {
       typeinfo <- type.inq.nc(x, id, fields=TRUE)
       if (typeinfo$class == "compound") {
-        cat(indent, indent, "compound ", typeinfo$name, " {\n", sep="")
+        cat(indent, gap, "compound ", typeinfo$name, " {\n", sep="")
         field_names = names(typeinfo$subtype)
         field_types = unname(typeinfo$subtype)
         field_sizes = unname(typeinfo$dimsizes)
         for (item in seq_along(typeinfo$subtype)) {
-          cat(indent, indent, indent, field_types[item], " ",
+          cat(indent, gap, gap, field_types[item], " ",
               field_names[item], sep="")
           if (!is.null(field_sizes[[item]])) {
             cat("(", paste(field_sizes[[item]], collapse=","), ")", sep="")
           }
           cat(" ;\n")
         }
-        cat(indent, indent, "}; // ", typeinfo$name, "\n", sep="")
+        cat(indent, gap, "}; // ", typeinfo$name, "\n", sep="")
       } else if (typeinfo$class == "enum") {
-        cat(indent, indent, typeinfo$basetype, " enum ", typeinfo$name,
+        cat(indent, gap, typeinfo$basetype, " enum ", typeinfo$name,
             " {\n", sep="")
         member_names <- names(typeinfo$value)
         member_values <- unname(typeinfo$value)
         for (item in seq_along(typeinfo$value)) {
-          cat(indent, indent, indent, member_names[item],
+          cat(indent, gap, gap, "\"", member_names[item], "\"",
               " = ", member_values[item], ",\n", sep="")
         }
-        cat(indent, indent, "} ; // ", typeinfo$name, "\n", sep="")
+        cat(indent, gap, "} ; // ", typeinfo$name, "\n", sep="")
       } else if (typeinfo$class == "opaque") {
-        cat(indent, indent, "opaque(", typeinfo$size, ") ", typeinfo$name,
+        cat(indent, gap, "opaque(", typeinfo$size, ") ", typeinfo$name,
             " ;\n", sep="")
       } else if (typeinfo$class == "vlen") {
-        cat(indent, indent, typeinfo$basetype, "(*) ", typeinfo$name,
+        cat(indent, gap, typeinfo$basetype, "(*) ", typeinfo$name,
             " ;\n", sep="")
       }
     }
@@ -379,7 +382,7 @@ print_grp <- function(x, level = 0) {
     for (id in grpinfo$varids) {
       varinfo <- var.inq.nc(x, id)
       vartype <- varinfo$type
-      cat(indent, "        ", vartype, " ", varinfo$name, sep = "")
+      cat(indent, tab, vartype, " ", varinfo$name, sep = "")
       if (varinfo$ndims > 0) {
         cat("(")
         for (jj in seq_len(varinfo$ndims - 1)) {
@@ -420,9 +423,10 @@ print_grp <- function(x, level = 0) {
       subgrpinfo <- grp.inq.nc(id, ancestors = FALSE)
       cat("\n", indent, "group: ", subgrpinfo$name, " {\n", sep = "")
       print_grp(id, level = (level + 1))
-      cat(indent, "  } // group ", subgrpinfo$name, "\n", sep = "")
+      cat(indent, gap, "} // group ", subgrpinfo$name, "\n", sep = "")
     }
   }
+
 }
 
 print.nc <- function(x, ...) {

--- a/man/print.nc.Rd
+++ b/man/print.nc.Rd
@@ -13,9 +13,9 @@
   \item{...}{Arguments passed to or from other methods (not used).}
 }
 
-\details{This function prints information about a NetCDF dataset. This includes a list of all dimensions and their length, a list of all variables and their attributes (including their values) and a list of all global attributes (including their values).
+\details{This function prints information about the structure of a NetCDF dataset, including lists of all groups, dimensions, user-defined types, variables and attributes.
 
-The output of this function is almost identical with a \code{"ncdump -h"} call. Because arrays in R have their leftmost subscript varying fastest, the fastest varying dimensions are printed first.
+The output of this function is similar to the \code{ncdump -h} command supplied with the NetCDF C library. One important difference is that array dimensions are shown by \code{print.nc} in the order used by R, where the leftmost subscript varies fastest.
 }
 
 \references{\url{http://www.unidata.ucar.edu/software/netcdf/}}

--- a/src/convert.c
+++ b/src/convert.c
@@ -1203,6 +1203,14 @@ R_nc_compound_vecsxp (R_nc_buf *io)
 
     /* Append field dimensions to the variable dimensions */
     ndim = io->ndim;
+    if (ndim < 0) {
+      /* Special case to drop dimensions of a vector,
+         but dimensions are needed for a compound vector.
+       */
+      ndim = 1;
+    }
+
+    ndim = io->ndim < 0 ? 1 : io->ndim ;
     ndimslice = ndim + ndimfld;
     dimslice = (size_t *) R_alloc (ndimslice, sizeof(size_t));
     for (idim=0; idim<ndim; idim++) {

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -249,13 +249,20 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
 
   ## Define some user-defined test attributes:
   if (format == "netcdf4") {
-    person1 <- list(siteid=array(person$siteid[1:3,1], 3),
+    person1 <- list(siteid=array(person$siteid[1,1], 1),
+                    height=array(person$height[1,1], 1),
+                    colour=array(person$colour[,1,1], c(3,1)))
+    person3 <- list(siteid=array(person$siteid[1:3,1], 3),
                     height=array(person$height[1:3,1], 3),
                     colour=array(person$colour[,1:3,1], c(3,3)))
-    att.put.nc(nc, "NC_GLOBAL", "compound_att", "struct", person1)
-    att.put.nc(nc, "NC_GLOBAL", "enum_att", "factor", snacks[1])
-    att.put.nc(nc, "NC_GLOBAL", "opaque_att", "blob", rawdata[,1,1])
-    att.put.nc(nc, "NC_GLOBAL", "vector_att", "vector", profiles[1])
+    att.put.nc(nc, "NC_GLOBAL", "compound_scal_att", "struct", person1)
+    att.put.nc(nc, "NC_GLOBAL", "compound_vect_att", "struct", person3)
+    att.put.nc(nc, "NC_GLOBAL", "enum_scal_att", "factor", snacks[1])
+    att.put.nc(nc, "NC_GLOBAL", "enum_vect_att", "factor", snacks[1:3])
+    att.put.nc(nc, "NC_GLOBAL", "opaque_scal_att", "blob", rawdata[,1,1])
+    att.put.nc(nc, "NC_GLOBAL", "opaque_vect_att", "blob", rawdata[,1,])
+    att.put.nc(nc, "NC_GLOBAL", "vector_scal_att", "vector", profiles[1])
+    att.put.nc(nc, "NC_GLOBAL", "vector_vect_att", "vector", profiles[1:3])
   }
 
   ##  Put the data
@@ -636,25 +643,45 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
     y <- var.get.nc(nc, "person")
     tally <- testfun(x,y,tally)
 
-    cat("Read compound attribute ...")
+    cat("Read compound scalar attribute ...")
     x <- person1
-    y <- att.get.nc(nc, "NC_GLOBAL", "compound_att")
+    y <- att.get.nc(nc, "NC_GLOBAL", "compound_scal_att")
     tally <- testfun(x,y,tally)
 
-    cat("Read enum attribute ...")
+    cat("Read compound vector attribute ...")
+    x <- person3
+    y <- att.get.nc(nc, "NC_GLOBAL", "compound_vect_att")
+    tally <- testfun(x,y,tally)
+
+    cat("Read enum scalar attribute ...")
     x <- snacks[1]
-    y <- att.get.nc(nc, "NC_GLOBAL", "enum_att")
+    y <- att.get.nc(nc, "NC_GLOBAL", "enum_scal_att")
     tally <- testfun(x,y,tally)
 
-    cat("Read opaque attribute ...")
+    cat("Read enum vector attribute ...")
+    x <- snacks[1:3]
+    y <- att.get.nc(nc, "NC_GLOBAL", "enum_vect_att")
+    tally <- testfun(x,y,tally)
+
+    cat("Read opaque scalar attribute ...")
     x <- rawdata[,1,1]
     dim(x) <- c(length(x),1)
-    y <- att.get.nc(nc, "NC_GLOBAL", "opaque_att")
+    y <- att.get.nc(nc, "NC_GLOBAL", "opaque_scal_att")
     tally <- testfun(x,y,tally)
 
-    cat("Read vlen attribute ...")
+    cat("Read opaque vector attribute ...")
+    x <- rawdata[,1,]
+    y <- att.get.nc(nc, "NC_GLOBAL", "opaque_vect_att")
+    tally <- testfun(x,y,tally)
+
+    cat("Read vlen scalar attribute ...")
     x <- profiles[1]
-    y <- att.get.nc(nc, "NC_GLOBAL", "vector_att")
+    y <- att.get.nc(nc, "NC_GLOBAL", "vector_scal_att")
+    tally <- testfun(x,y,tally)
+
+    cat("Read vlen vector attribute ...")
+    x <- profiles[1:3]
+    y <- att.get.nc(nc, "NC_GLOBAL", "vector_vect_att")
     tally <- testfun(x,y,tally)
 
   }

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -247,6 +247,17 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
                    colour=array(rep(c(0,0,0,64,128,192),nstation), c(3,nstation,ntime)))
   }
 
+  ## Define some user-defined test attributes:
+  if (format == "netcdf4") {
+    person1 <- list(siteid=array(person$siteid[1:3,1], 3),
+                    height=array(person$height[1:3,1], 3),
+                    colour=array(person$colour[,1:3,1], c(3,3)))
+    att.put.nc(nc, "NC_GLOBAL", "compound_att", "struct", person1)
+    att.put.nc(nc, "NC_GLOBAL", "enum_att", "factor", snacks[1])
+    att.put.nc(nc, "NC_GLOBAL", "opaque_att", "blob", rawdata[,1,1])
+    att.put.nc(nc, "NC_GLOBAL", "vector_att", "vector", profiles[1])
+  }
+
   ##  Put the data
   cat("Writing variables ...\n")
   var.put.nc(nc, "time", mytime, 1, length(mytime))
@@ -624,6 +635,28 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
     x <- person
     y <- var.get.nc(nc, "person")
     tally <- testfun(x,y,tally)
+
+    cat("Read compound attribute ...")
+    x <- person1
+    y <- att.get.nc(nc, "NC_GLOBAL", "compound_att")
+    tally <- testfun(x,y,tally)
+
+    cat("Read enum attribute ...")
+    x <- snacks[1]
+    y <- att.get.nc(nc, "NC_GLOBAL", "enum_att")
+    tally <- testfun(x,y,tally)
+
+    cat("Read opaque attribute ...")
+    x <- rawdata[,1,1]
+    dim(x) <- c(length(x),1)
+    y <- att.get.nc(nc, "NC_GLOBAL", "opaque_att")
+    tally <- testfun(x,y,tally)
+
+    cat("Read vlen attribute ...")
+    x <- profiles[1]
+    y <- att.get.nc(nc, "NC_GLOBAL", "vector_att")
+    tally <- testfun(x,y,tally)
+
   }
 
   cat("Read and unpack numeric array ... ")

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -323,7 +323,10 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   } else {
     close.nc(nc)
     nc <- open.nc(ncfile)
-  } 
+  }
+
+  ## Display file structure
+  print.nc(nc)
 
   ## Read tests
 


### PR DESCRIPTION
Resolves #37 .

`print.nc` now shows definitions of user-defined types, and it also reports the existence of user-defined attributes and variables. Values of user-defined attributes can be very complicated, so they are not shown by the current implementation. User-defined attributes can be read by `att.get.nc` if required. The information presented by `print.nc` should be enough to reveal the structure of any netcdf dataset.

Related tasks included:
* Handling scalars and vectors of user-defined type in attributes
* Expanding tests of user-defined types in attributes
* Handling class `integer64` while keeping package `bit64` an optional dependency