### PR TITLE
Show NetCDF library version

### DIFF
--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -252,7 +252,7 @@ file.inq.nc <- function(ncfile) {
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_inq_file, ncfile)
   
-  names(nc) <- c("ndims", "nvars", "ngatts", "unlimdimid", "format")
+  names(nc) <- c("ndims", "nvars", "ngatts", "unlimdimid", "format", "libvers")
   
   return(nc)
 }

--- a/man/file.inq.nc.Rd
+++ b/man/file.inq.nc.Rd
@@ -19,9 +19,8 @@
   \item{ngatts}{Number of global attributes for this NetCDF dataset.}
   \item{unlimdimid}{ID of the unlimited dimension, if there is one for this NetCDF dataset. Otherwise \code{NA} will be returned.} 
   \item{format}{Format of file, typically "classic", "offset64", "classic4" or "netcdf4".}
+  \item{libvers}{Version string of the NetCDF library in the current R session.}
 }
-
-\details{This function returns values for the number of dimensions, the number of variables, the number of global attributes, the dimension ID of the dimension defined with unlimited length (if any), and the format of the file.}
 
 \references{\url{http://www.unidata.ucar.edu/software/netcdf/}}
 

--- a/src/dataset.c
+++ b/src/dataset.c
@@ -180,6 +180,7 @@ SEXP
 R_nc_inq_file (SEXP nc)
 {
   int ncid, ndims, nvars, ngatts, unlimdimid, format;
+  const char *libvers;
   SEXP result;
 
   /*-- Convert arguments to netcdf ids ----------------------------------------*/
@@ -191,16 +192,18 @@ R_nc_inq_file (SEXP nc)
     unlimdimid = NA_INTEGER;
   }
 
-  /*-- Inquire about the NetCDF format ----------------------------------------*/
+  /*-- Inquire about the NetCDF format and library version --------------------*/
   R_nc_check (nc_inq_format (ncid, &format));
+  libvers = nc_inq_libvers ();
 
   /*-- Returning the list -----------------------------------------------------*/
-  result = R_nc_protect (allocVector (VECSXP, 5)); 
+  result = R_nc_protect (allocVector (VECSXP, 6)); 
   SET_VECTOR_ELT (result, 0, ScalarInteger (ndims));
   SET_VECTOR_ELT (result, 1, ScalarInteger (nvars));
   SET_VECTOR_ELT (result, 2, ScalarInteger (ngatts));
   SET_VECTOR_ELT (result, 3, ScalarInteger (unlimdimid));
   SET_VECTOR_ELT (result, 4, mkString (R_nc_format2str (format)));
+  SET_VECTOR_ELT (result, 5, mkString (libvers));
 
   RRETURN(result);
 }

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -325,6 +325,11 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
     nc <- open.nc(ncfile)
   }
 
+  cat("Check file format ...")
+  x <- file.inq.nc(nc)$format
+  y <- format
+  tally <- testfun(x,y,tally)
+
   ## Display file structure
   print.nc(nc)
 


### PR DESCRIPTION
Resolves #51 .

Some applications may be sensitive to the version of the NetCDF library. We expose the library version to users by adding a new element `libvers` to the output list from `file.inq.nc`.

Although the library version is not strictly a property of a NetCDF dataset, the library version is fixed while a dataset is open in RNetCDF. `file.inq.nc` reports properties of an open dataset, and it is therefore an appropriate function to report the library version.