### PR TITLE
Advanced settings for variables in netcdf4

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -5,9 +5,9 @@ installation of the RNetCDF package and gives some further hints.
 Software Requirements
 =====================
 
-NetCDF library version 4.0.1 or greater.
+NetCDF library version 4.1.3 or greater.
 
-UDUNITS library version 2.1 or greater.
+UDUNITS library version 2.0.4 or greater.
 
 If using Fink on Mac OS X, be sure that the corresponding R version (either
 i386 or x86_64) is used (R32 or R64). Compiling with R64 against i386 will

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -504,7 +504,8 @@ var.def.nc <- function(ncfile, varname, vartype, dimensions,
 #-------------------------------------------------------------------------------
 
 var.get.nc <- function(ncfile, variable, start = NA, count = NA, na.mode = 4, 
-  collapse = TRUE, unpack = FALSE, rawchar = FALSE, fitnum = FALSE) {
+  collapse = TRUE, unpack = FALSE, rawchar = FALSE, fitnum = FALSE,
+  cache_bytes=NA, cache_slots=NA, cache_preemption=NA) {
   #-- Check args -------------------------------------------------------------
   stopifnot(class(ncfile) == "NetCDF")
   stopifnot(is.character(variable) || is.numeric(variable))
@@ -514,6 +515,9 @@ var.get.nc <- function(ncfile, variable, start = NA, count = NA, na.mode = 4,
   stopifnot(is.logical(unpack))
   stopifnot(is.logical(rawchar))
   stopifnot(is.logical(fitnum))
+  stopifnot(is.logical(cache_bytes) || is.numeric(cache_bytes))
+  stopifnot(is.logical(cache_slots) || is.numeric(cache_slots))
+  stopifnot(is.logical(cache_preemption) || is.numeric(cache_preemption))
   
   # Truncate start & count and replace NA as described in the man page:
   varinfo <- var.inq.nc(ncfile, variable)
@@ -542,7 +546,8 @@ var.get.nc <- function(ncfile, variable, start = NA, count = NA, na.mode = 4,
 
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_get_var, ncfile, variable, start, count,
-              rawchar, fitnum, na.mode, unpack)
+              rawchar, fitnum, na.mode, unpack,
+              cache_bytes, cache_slots, cache_preemption)
 
   if (inherits(nc, "integer64") &&
       !requireNamespace("bit64", quietly=TRUE)) {
@@ -591,7 +596,8 @@ var.inq.nc <- function(ncfile, variable) {
 #-------------------------------------------------------------------------------
 
 var.put.nc <- function(ncfile, variable, data, start = NA, count = NA,
-  na.mode = 4, pack = FALSE) {
+  na.mode = 4, pack = FALSE,
+  cache_bytes=NA, cache_slots=NA, cache_preemption=NA) {
   #-- Check args -------------------------------------------------------------
   stopifnot(class(ncfile) == "NetCDF")
   stopifnot(is.character(variable) || is.numeric(variable))
@@ -600,6 +606,9 @@ var.put.nc <- function(ncfile, variable, data, start = NA, count = NA,
   stopifnot(is.numeric(start) || is.logical(start))
   stopifnot(is.numeric(count) || is.logical(count))
   stopifnot(is.logical(pack))
+  stopifnot(is.logical(cache_bytes) || is.numeric(cache_bytes))
+  stopifnot(is.logical(cache_slots) || is.numeric(cache_slots))
+  stopifnot(is.logical(cache_preemption) || is.numeric(cache_preemption))
   
   # Determine type and dimensions of variable:
   varinfo <- var.inq.nc(ncfile, variable)
@@ -700,7 +709,8 @@ var.put.nc <- function(ncfile, variable, data, start = NA, count = NA,
 
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_put_var, ncfile, variable, start, count, data,
-              na.mode, pack)
+              na.mode, pack,
+              cache_bytes, cache_slots, cache_preemption)
  
   return(invisible(NULL))
 }

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -585,7 +585,8 @@ var.inq.nc <- function(ncfile, variable) {
     names(nc) <- c("id", "name", "type", "ndims", "dimids", "natts",
                    "chunksizes", "cache_bytes", "cache_slots",
                    "cache_preemption", "deflate", "shuffle", "big_endian",
-                   "fletcher32", "szip_options", "szip_bits")
+                   "fletcher32", "szip_options", "szip_bits",
+                   "filter_id", "filter_params")
   }
   
   return(nc)

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -177,12 +177,14 @@ create.nc <- function(filename, clobber = TRUE, share = FALSE, prefill = TRUE,
   stopifnot(is.logical(clobber))
   stopifnot(is.logical(share))
   stopifnot(is.logical(prefill))
-  stopifnot(is.character(format))
+  stopifnot(is.character(format) &&
+            format[1] %in% c("classic", "offset64", "netcdf4", "classic4"))
   stopifnot(is.logical(large))
 
   # Handle deprecated argument:
-  if (isTRUE(large) && format == "classic") {
+  if (isTRUE(large) && format[1] == "classic") {
     format <- "offset64"
+    warning("Argument 'large' is deprecated; please specify 'format' instead")
   }
   
   #-- C function call --------------------------------------------------------

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -480,7 +480,8 @@ sync.nc <- function(ncfile) {
 var.def.nc <- function(ncfile, varname, vartype, dimensions,
                        chunking=NA, chunksizes=NULL,
                        deflate=NA, shuffle=FALSE, big_endian=NA,
-                       fletcher32=FALSE) {
+                       fletcher32=FALSE, filter_id=NA,
+                       filter_params=integer(0)) {
   #-- Check args -------------------------------------------------------------
   stopifnot(class(ncfile) == "NetCDF")
   stopifnot(is.character(varname))
@@ -497,11 +498,13 @@ var.def.nc <- function(ncfile, varname, vartype, dimensions,
   stopifnot(is.logical(shuffle))
   stopifnot(is.logical(big_endian))
   stopifnot(is.logical(fletcher32))
+  stopifnot(isTRUE(is.na(filter_id)) || is.numeric(filter_id))
+  stopifnot(is.integer(filter_params))
 
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_def_var, ncfile, varname, vartype, dimensions,
               chunking, chunksizes, deflate, shuffle, big_endian,
-              fletcher32)
+              fletcher32, filter_id, filter_params)
   
   return(invisible(nc))
 }

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -470,7 +470,8 @@ sync.nc <- function(ncfile) {
 # var.def.nc()
 #-------------------------------------------------------------------------------
 
-var.def.nc <- function(ncfile, varname, vartype, dimensions) {
+var.def.nc <- function(ncfile, varname, vartype, dimensions,
+                       chunking=NA, chunksizes=NULL) {
   #-- Check args -------------------------------------------------------------
   stopifnot(class(ncfile) == "NetCDF")
   stopifnot(is.character(varname))
@@ -481,9 +482,12 @@ var.def.nc <- function(ncfile, varname, vartype, dimensions) {
   }
 
   stopifnot(is.character(dimensions) || is.numeric(dimensions))
+  stopifnot(is.logical(chunking))
+  stopifnot(is.null(chunksizes) || is.numeric(chunksizes))
 
   #-- C function call --------------------------------------------------------
-  nc <- .Call(R_nc_def_var, ncfile, varname, vartype, dimensions)
+  nc <- .Call(R_nc_def_var, ncfile, varname, vartype, dimensions,
+              chunking, chunksizes)
   
   return(invisible(nc))
 }

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -179,6 +179,11 @@ create.nc <- function(filename, clobber = TRUE, share = FALSE, prefill = TRUE,
   stopifnot(is.logical(prefill))
   stopifnot(is.character(format))
   stopifnot(is.logical(large))
+
+  # Handle deprecated argument:
+  if (isTRUE(large) && format == "classic") {
+    format <- "offset64"
+  }
   
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_create, filename, clobber, share, prefill, format)

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -563,7 +563,8 @@ var.inq.nc <- function(ncfile, variable) {
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_inq_var, ncfile, variable)
   
-  names(nc) <- c("id", "name", "type", "ndims", "dimids", "natts")
+  names(nc) <- c("id", "name", "type", "ndims", "dimids", "natts",
+                 "chunksizes")
   
   return(nc)
 }

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -567,7 +567,8 @@ var.inq.nc <- function(ncfile, variable) {
     names(nc) <- c("id", "name", "type", "ndims", "dimids", "natts")
   } else {
     names(nc) <- c("id", "name", "type", "ndims", "dimids", "natts",
-                   "chunksizes")
+                   "chunksizes", "cache_bytes", "cache_slots",
+                   "cache_preemption")
   }
   
   return(nc)

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -584,7 +584,7 @@ var.inq.nc <- function(ncfile, variable) {
   } else {
     names(nc) <- c("id", "name", "type", "ndims", "dimids", "natts",
                    "chunksizes", "cache_bytes", "cache_slots",
-                   "cache_preemption", "deflate", "shuffle")
+                   "cache_preemption", "deflate", "shuffle", "big_endian")
   }
   
   return(nc)

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -584,7 +584,7 @@ var.inq.nc <- function(ncfile, variable) {
   } else {
     names(nc) <- c("id", "name", "type", "ndims", "dimids", "natts",
                    "chunksizes", "cache_bytes", "cache_slots",
-                   "cache_preemption")
+                   "cache_preemption", "deflate", "shuffle")
   }
   
   return(nc)

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -562,9 +562,13 @@ var.inq.nc <- function(ncfile, variable) {
   
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_inq_var, ncfile, variable)
-  
-  names(nc) <- c("id", "name", "type", "ndims", "dimids", "natts",
-                 "chunksizes")
+
+  if (length(nc) == 6) {
+    names(nc) <- c("id", "name", "type", "ndims", "dimids", "natts")
+  } else {
+    names(nc) <- c("id", "name", "type", "ndims", "dimids", "natts",
+                   "chunksizes")
+  }
   
   return(nc)
 }

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -585,7 +585,7 @@ var.inq.nc <- function(ncfile, variable) {
     names(nc) <- c("id", "name", "type", "ndims", "dimids", "natts",
                    "chunksizes", "cache_bytes", "cache_slots",
                    "cache_preemption", "deflate", "shuffle", "big_endian",
-                   "fletcher32")
+                   "fletcher32", "szip_options", "szip_bits")
   }
   
   return(nc)

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -479,7 +479,7 @@ sync.nc <- function(ncfile) {
 
 var.def.nc <- function(ncfile, varname, vartype, dimensions,
                        chunking=NA, chunksizes=NULL,
-                       deflate=NA, shuffle=FALSE) {
+                       deflate=NA, shuffle=FALSE, big_endian=NA) {
   #-- Check args -------------------------------------------------------------
   stopifnot(class(ncfile) == "NetCDF")
   stopifnot(is.character(varname))
@@ -494,10 +494,11 @@ var.def.nc <- function(ncfile, varname, vartype, dimensions,
   stopifnot(is.null(chunksizes) || is.numeric(chunksizes))
   stopifnot(isTRUE(is.na(deflate)) || is.numeric(deflate))
   stopifnot(is.logical(shuffle))
+  stopifnot(is.logical(big_endian))
 
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_def_var, ncfile, varname, vartype, dimensions,
-              chunking, chunksizes, deflate, shuffle)
+              chunking, chunksizes, deflate, shuffle, big_endian)
   
   return(invisible(nc))
 }

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -479,7 +479,8 @@ sync.nc <- function(ncfile) {
 
 var.def.nc <- function(ncfile, varname, vartype, dimensions,
                        chunking=NA, chunksizes=NULL,
-                       deflate=NA, shuffle=FALSE, big_endian=NA) {
+                       deflate=NA, shuffle=FALSE, big_endian=NA,
+                       fletcher32=FALSE) {
   #-- Check args -------------------------------------------------------------
   stopifnot(class(ncfile) == "NetCDF")
   stopifnot(is.character(varname))
@@ -495,10 +496,12 @@ var.def.nc <- function(ncfile, varname, vartype, dimensions,
   stopifnot(isTRUE(is.na(deflate)) || is.numeric(deflate))
   stopifnot(is.logical(shuffle))
   stopifnot(is.logical(big_endian))
+  stopifnot(is.logical(fletcher32))
 
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_def_var, ncfile, varname, vartype, dimensions,
-              chunking, chunksizes, deflate, shuffle, big_endian)
+              chunking, chunksizes, deflate, shuffle, big_endian,
+              fletcher32)
   
   return(invisible(nc))
 }

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -584,7 +584,8 @@ var.inq.nc <- function(ncfile, variable) {
   } else {
     names(nc) <- c("id", "name", "type", "ndims", "dimids", "natts",
                    "chunksizes", "cache_bytes", "cache_slots",
-                   "cache_preemption", "deflate", "shuffle", "big_endian")
+                   "cache_preemption", "deflate", "shuffle", "big_endian",
+                   "fletcher32")
   }
   
   return(nc)

--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -478,7 +478,8 @@ sync.nc <- function(ncfile) {
 #-------------------------------------------------------------------------------
 
 var.def.nc <- function(ncfile, varname, vartype, dimensions,
-                       chunking=NA, chunksizes=NULL) {
+                       chunking=NA, chunksizes=NULL,
+                       deflate=NA, shuffle=FALSE) {
   #-- Check args -------------------------------------------------------------
   stopifnot(class(ncfile) == "NetCDF")
   stopifnot(is.character(varname))
@@ -491,10 +492,12 @@ var.def.nc <- function(ncfile, varname, vartype, dimensions,
   stopifnot(is.character(dimensions) || is.numeric(dimensions))
   stopifnot(is.logical(chunking))
   stopifnot(is.null(chunksizes) || is.numeric(chunksizes))
+  stopifnot(isTRUE(is.na(deflate)) || is.numeric(deflate))
+  stopifnot(is.logical(shuffle))
 
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_def_var, ncfile, varname, vartype, dimensions,
-              chunking, chunksizes)
+              chunking, chunksizes, deflate, shuffle)
   
   return(invisible(nc))
 }

--- a/configure
+++ b/configure
@@ -3444,6 +3444,18 @@ cat >>confdefs.h <<_ACEOF
 #define HAVE_DECL_NC_GET_VAR_CHUNK_CACHE $ac_have_decl
 _ACEOF
 
+ac_fn_c_check_decl "$LINENO" "nc_inq_var_szip" "ac_cv_have_decl_nc_inq_var_szip" "#include <netcdf.h>
+"
+if test "x$ac_cv_have_decl_nc_inq_var_szip" = xyes; then :
+  ac_have_decl=1
+else
+  ac_have_decl=0
+fi
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_NC_INQ_VAR_SZIP $ac_have_decl
+_ACEOF
+
 
 #-------------------------------------------------------------------------------#
 #  Find UDUNITS2 library and header files                                       #

--- a/configure
+++ b/configure
@@ -3432,6 +3432,18 @@ cat >>confdefs.h <<_ACEOF
 #define HAVE_DECL_NC_RENAME_GRP $ac_have_decl
 _ACEOF
 
+ac_fn_c_check_decl "$LINENO" "nc_get_var_chunk_cache" "ac_cv_have_decl_nc_get_var_chunk_cache" "#include <netcdf.h>
+"
+if test "x$ac_cv_have_decl_nc_get_var_chunk_cache" = xyes; then :
+  ac_have_decl=1
+else
+  ac_have_decl=0
+fi
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_NC_GET_VAR_CHUNK_CACHE $ac_have_decl
+_ACEOF
+
 
 #-------------------------------------------------------------------------------#
 #  Find UDUNITS2 library and header files                                       #

--- a/configure
+++ b/configure
@@ -3456,6 +3456,18 @@ cat >>confdefs.h <<_ACEOF
 #define HAVE_DECL_NC_INQ_VAR_SZIP $ac_have_decl
 _ACEOF
 
+ac_fn_c_check_decl "$LINENO" "nc_inq_var_filter" "ac_cv_have_decl_nc_inq_var_filter" "#include <netcdf.h>
+"
+if test "x$ac_cv_have_decl_nc_inq_var_filter" = xyes; then :
+  ac_have_decl=1
+else
+  ac_have_decl=0
+fi
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_NC_INQ_VAR_FILTER $ac_have_decl
+_ACEOF
+
 
 #-------------------------------------------------------------------------------#
 #  Find UDUNITS2 library and header files                                       #

--- a/configure
+++ b/configure
@@ -1664,51 +1664,72 @@ fi
 
 } # ac_fn_c_try_link
 
-# ac_fn_c_check_decl LINENO SYMBOL VAR INCLUDES
-# ---------------------------------------------
-# Tests whether SYMBOL is declared in INCLUDES, setting cache variable VAR
-# accordingly.
-ac_fn_c_check_decl ()
+# ac_fn_c_check_func LINENO FUNC VAR
+# ----------------------------------
+# Tests whether FUNC exists, setting the cache variable VAR accordingly
+ac_fn_c_check_func ()
 {
   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  as_decl_name=`echo $2|sed 's/ *(.*//'`
-  as_decl_use=`echo $2|sed -e 's/(/((/' -e 's/)/) 0&/' -e 's/,/) 0& (/g'`
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $as_decl_name is declared" >&5
-$as_echo_n "checking whether $as_decl_name is declared... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+$as_echo_n "checking for $2... " >&6; }
 if eval \${$3+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-$4
+/* Define $2 to an innocuous variant, in case <limits.h> declares $2.
+   For example, HP-UX 11i <limits.h> declares gettimeofday.  */
+#define $2 innocuous_$2
+
+/* System header to define __stub macros and hopefully few prototypes,
+    which can conflict with char $2 (); below.
+    Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
+    <limits.h> exists even on freestanding compilers.  */
+
+#ifdef __STDC__
+# include <limits.h>
+#else
+# include <assert.h>
+#endif
+
+#undef $2
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char $2 ();
+/* The GNU C library defines this for functions which it implements
+    to always fail with ENOSYS.  Some functions are actually named
+    something starting with __ and the normal name is an alias.  */
+#if defined __stub_$2 || defined __stub___$2
+choke me
+#endif
+
 int
 main ()
 {
-#ifndef $as_decl_name
-#ifdef __cplusplus
-  (void) $as_decl_use;
-#else
-  (void) $as_decl_name;
-#endif
-#endif
-
+return $2 ();
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
+if ac_fn_c_try_link "$LINENO"; then :
   eval "$3=yes"
 else
   eval "$3=no"
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
 fi
 eval ac_res=\$$3
 	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
 $as_echo "$ac_res" >&6; }
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
-} # ac_fn_c_check_decl
+} # ac_fn_c_check_func
 cat >config.log <<_ACEOF
 This file contains any messages produced by compilers while
 running configure, to aid debugging if configure makes a mistake.
@@ -3418,55 +3439,18 @@ fi
 
 
 # Check for the existence of optional netcdf routines.
-# Afterwards, C preprocessor macros HAVE_DECL_symbols are defined,
-# with value 1 if routine is declared or 0 if not.
-ac_fn_c_check_decl "$LINENO" "nc_rename_grp" "ac_cv_have_decl_nc_rename_grp" "#include <netcdf.h>
-"
-if test "x$ac_cv_have_decl_nc_rename_grp" = xyes; then :
-  ac_have_decl=1
-else
-  ac_have_decl=0
-fi
-
-cat >>confdefs.h <<_ACEOF
-#define HAVE_DECL_NC_RENAME_GRP $ac_have_decl
+# C preprocessor macros HAVE_routine are defined for existing routines.
+for ac_func in nc_rename_grp nc_get_var_chunk_cache nc_inq_var_szip nc_inq_var_endian nc_inq_var_filter
+do :
+  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
 _ACEOF
 
-ac_fn_c_check_decl "$LINENO" "nc_get_var_chunk_cache" "ac_cv_have_decl_nc_get_var_chunk_cache" "#include <netcdf.h>
-"
-if test "x$ac_cv_have_decl_nc_get_var_chunk_cache" = xyes; then :
-  ac_have_decl=1
-else
-  ac_have_decl=0
 fi
-
-cat >>confdefs.h <<_ACEOF
-#define HAVE_DECL_NC_GET_VAR_CHUNK_CACHE $ac_have_decl
-_ACEOF
-
-ac_fn_c_check_decl "$LINENO" "nc_inq_var_szip" "ac_cv_have_decl_nc_inq_var_szip" "#include <netcdf.h>
-"
-if test "x$ac_cv_have_decl_nc_inq_var_szip" = xyes; then :
-  ac_have_decl=1
-else
-  ac_have_decl=0
-fi
-
-cat >>confdefs.h <<_ACEOF
-#define HAVE_DECL_NC_INQ_VAR_SZIP $ac_have_decl
-_ACEOF
-
-ac_fn_c_check_decl "$LINENO" "nc_inq_var_filter" "ac_cv_have_decl_nc_inq_var_filter" "#include <netcdf.h>
-"
-if test "x$ac_cv_have_decl_nc_inq_var_filter" = xyes; then :
-  ac_have_decl=1
-else
-  ac_have_decl=0
-fi
-
-cat >>confdefs.h <<_ACEOF
-#define HAVE_DECL_NC_INQ_VAR_FILTER $ac_have_decl
-_ACEOF
+done
 
 
 #-------------------------------------------------------------------------------#

--- a/configure.ac
+++ b/configure.ac
@@ -62,6 +62,7 @@ AC_SEARCH_LIBS(nc_open, netcdf, [],
 # Afterwards, C preprocessor macros HAVE_DECL_symbols are defined,
 # with value 1 if routine is declared or 0 if not.
 AC_CHECK_DECLS([nc_rename_grp], [], [], [[#include <netcdf.h>]])
+AC_CHECK_DECLS([nc_get_var_chunk_cache], [], [], [[#include <netcdf.h>]])
 
 #-------------------------------------------------------------------------------#
 #  Find UDUNITS2 library and header files                                       #

--- a/configure.ac
+++ b/configure.ac
@@ -59,12 +59,8 @@ AC_SEARCH_LIBS(nc_open, netcdf, [],
     AC_MSG_ERROR("netcdf library was not linked - defining LDFLAGS may help"))
 
 # Check for the existence of optional netcdf routines.
-# Afterwards, C preprocessor macros HAVE_DECL_symbols are defined,
-# with value 1 if routine is declared or 0 if not.
-AC_CHECK_DECLS([nc_rename_grp], [], [], [[#include <netcdf.h>]])
-AC_CHECK_DECLS([nc_get_var_chunk_cache], [], [], [[#include <netcdf.h>]])
-AC_CHECK_DECLS([nc_inq_var_szip], [], [], [[#include <netcdf.h>]])
-AC_CHECK_DECLS([nc_inq_var_filter], [], [], [[#include <netcdf.h>]])
+# C preprocessor macros HAVE_routine are defined for existing routines.
+AC_CHECK_FUNCS([nc_rename_grp nc_get_var_chunk_cache nc_inq_var_szip nc_inq_var_endian nc_inq_var_filter])
 
 #-------------------------------------------------------------------------------#
 #  Find UDUNITS2 library and header files                                       #

--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,7 @@ AC_SEARCH_LIBS(nc_open, netcdf, [],
 AC_CHECK_DECLS([nc_rename_grp], [], [], [[#include <netcdf.h>]])
 AC_CHECK_DECLS([nc_get_var_chunk_cache], [], [], [[#include <netcdf.h>]])
 AC_CHECK_DECLS([nc_inq_var_szip], [], [], [[#include <netcdf.h>]])
+AC_CHECK_DECLS([nc_inq_var_filter], [], [], [[#include <netcdf.h>]])
 
 #-------------------------------------------------------------------------------#
 #  Find UDUNITS2 library and header files                                       #

--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,7 @@ AC_SEARCH_LIBS(nc_open, netcdf, [],
 # with value 1 if routine is declared or 0 if not.
 AC_CHECK_DECLS([nc_rename_grp], [], [], [[#include <netcdf.h>]])
 AC_CHECK_DECLS([nc_get_var_chunk_cache], [], [], [[#include <netcdf.h>]])
+AC_CHECK_DECLS([nc_inq_var_szip], [], [], [[#include <netcdf.h>]])
 
 #-------------------------------------------------------------------------------#
 #  Find UDUNITS2 library and header files                                       #

--- a/man/create.nc.Rd
+++ b/man/create.nc.Rd
@@ -15,7 +15,7 @@
   \item{share}{The buffer scheme. If \code{FALSE} (default), dataset access is buffered and cached for performance. However, if one or more processes may be reading while another process is writing the dataset, set to \code{TRUE}.}
   \item{prefill}{The prefill mode. If \code{TRUE} (default), newly defined variables are initialised with fill values when they are first accessed. This allows unwritten array elements to be detected when reading, but it also implies duplicate writes if all elements are subsequently written with user-specified data. Enhanced write performance can be obtained by setting \code{prefill=FALSE}.}
   \item{format}{The file format. One of "classic", "offset64", "netcdf4" or "classic4". See below for details.}
-  \item{large}{(Deprecated) \code{large=TRUE} is equivalent to \code{format="offset64"}.}
+  \item{large}{(Deprecated) \code{large=TRUE} sets the file format to "offset64" when \code{format="classic"}.}
 }
 
 \value{Object of class "\code{NetCDF}" which points to the NetCDF dataset, returned invisibly.}

--- a/man/var.def.nc.Rd
+++ b/man/var.def.nc.Rd
@@ -8,7 +8,7 @@
 
 \usage{var.def.nc(ncfile, varname, vartype, dimensions,
                   chunking=NA, chunksizes=NULL, deflate=NA, shuffle=FALSE,
-                  big_endian=NA)}
+                  big_endian=NA, fletcher32=FALSE)}
 
 \arguments{
   \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
@@ -21,6 +21,7 @@
   \item{deflate}{Integer indicating level of compression, from 0 (minimum) to 9 (maximum), or \code{NA} for no compression.}
   \item{shuffle}{\code{TRUE} to enable byte shuffling, which may improve compression with \code{deflate}.}
   \item{big_endian}{Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for native endianness of the platform.}
+  \item{fletcher32}{\code{TRUE} to enable the fletcher32 checksum.}
 }
 
 \value{NetCDF variable identifier, returned invisibly.}

--- a/man/var.def.nc.Rd
+++ b/man/var.def.nc.Rd
@@ -7,7 +7,8 @@
 \description{Define a new NetCDF variable.}
 
 \usage{var.def.nc(ncfile, varname, vartype, dimensions,
-                  chunking=NA, chunksizes=NULL, deflate=NA, shuffle=FALSE)}
+                  chunking=NA, chunksizes=NULL, deflate=NA, shuffle=FALSE,
+                  big_endian=NA)}
 
 \arguments{
   \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
@@ -19,6 +20,7 @@
   \item{chunksizes}{Chunk size expressed as the number of elements along each dimension, in the same order as \code{dimensions}. If \code{NULL}, the NetCDF library uses a default chunking strategy, which is intended to give reasonable performance in typical applications. Ignored unless \code{chunking} is \code{TRUE}.}
   \item{deflate}{Integer indicating level of compression for a chunked variable, from 0 (minimum) to 9 (maximum), or \code{NA} for no compression.}
   \item{shuffle}{\code{TRUE} to enable byte shuffling for a chunked variable, which may improve compression with \code{deflate}.}
+  \item{big_endian}{Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for native endianness of the platform.}
 }
 
 \value{NetCDF variable identifier, returned invisibly.}

--- a/man/var.def.nc.Rd
+++ b/man/var.def.nc.Rd
@@ -27,7 +27,7 @@
 
 \details{This function creates a new NetCDF variable. A NetCDF variable has a name, a type, and a shape, which are specified when it is defined. A variable may also have values, which are established later in data mode. 
 
-Ordinarily, the name, type, and shape are fixed when the variable is first defined. The name may be changed, but the type and shape of a variable cannot be changed. However, a variable defined in terms of the unlimited dimension can grow without bound in that dimension. The fastetst varying dimension has to be first in \code{dimensions}, the slowest varying dimension last (this is the same way as an array is defined in R; i.e., opposite to the CDL conventions).
+Ordinarily, the name, type, and shape are fixed when the variable is first defined. The name may be changed, but the type and shape of a variable cannot be changed. However, a variable defined in terms of the unlimited dimension can grow without bound in that dimension. The fastest varying dimension has to be first in \code{dimensions}, the slowest varying dimension last (this is the same way as an array is defined in R; i.e., opposite to the CDL conventions).
 
 A NetCDF variable in an open NetCDF dataset is referred to by a small integer called a variable ID. Variable IDs are 0, 1, 2,..., in the order in which the variables were defined within a NetCDF dataset.
 

--- a/man/var.def.nc.Rd
+++ b/man/var.def.nc.Rd
@@ -18,8 +18,8 @@
   The following arguments are optional for datasets in "netcdf4" format (and ignored for other formats):
   \item{chunking}{\code{TRUE} selects chunking, \code{FALSE} implies contiguous storage, \code{NA} allows the NetCDF library to choose a storage layout.}
   \item{chunksizes}{Chunk size expressed as the number of elements along each dimension, in the same order as \code{dimensions}. If \code{NULL}, the NetCDF library uses a default chunking strategy, which is intended to give reasonable performance in typical applications. Ignored unless \code{chunking} is \code{TRUE}.}
-  \item{deflate}{Integer indicating level of compression for a chunked variable, from 0 (minimum) to 9 (maximum), or \code{NA} for no compression.}
-  \item{shuffle}{\code{TRUE} to enable byte shuffling for a chunked variable, which may improve compression with \code{deflate}.}
+  \item{deflate}{Integer indicating level of compression, from 0 (minimum) to 9 (maximum), or \code{NA} for no compression.}
+  \item{shuffle}{\code{TRUE} to enable byte shuffling, which may improve compression with \code{deflate}.}
   \item{big_endian}{Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for native endianness of the platform.}
 }
 

--- a/man/var.def.nc.Rd
+++ b/man/var.def.nc.Rd
@@ -7,7 +7,7 @@
 \description{Define a new NetCDF variable.}
 
 \usage{var.def.nc(ncfile, varname, vartype, dimensions,
-                  chunking=NA, chunksizes=NULL)}
+                  chunking=NA, chunksizes=NULL, deflate=NA, shuffle=FALSE)}
 
 \arguments{
   \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
@@ -17,6 +17,8 @@
   The following arguments are optional for datasets in "netcdf4" format (and ignored for other formats):
   \item{chunking}{\code{TRUE} selects chunking, \code{FALSE} implies contiguous storage, \code{NA} allows the NetCDF library to choose a storage layout.}
   \item{chunksizes}{Chunk size expressed as the number of elements along each dimension, in the same order as \code{dimensions}. If \code{NULL}, the NetCDF library uses a default chunking strategy, which is intended to give reasonable performance in typical applications. Ignored unless \code{chunking} is \code{TRUE}.}
+  \item{deflate}{Integer indicating level of compression for a chunked variable, from 0 (minimum) to 9 (maximum), or \code{NA} for no compression.}
+  \item{shuffle}{\code{TRUE} to enable byte shuffling for a chunked variable, which may improve compression with \code{deflate}.}
 }
 
 \value{NetCDF variable identifier, returned invisibly.}

--- a/man/var.def.nc.Rd
+++ b/man/var.def.nc.Rd
@@ -6,13 +6,17 @@
 
 \description{Define a new NetCDF variable.}
 
-\usage{var.def.nc(ncfile, varname, vartype, dimensions)}
+\usage{var.def.nc(ncfile, varname, vartype, dimensions,
+                  chunking=NA, chunksizes=NULL)}
 
 \arguments{
   \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{varname}{Variable name. Must begin with an alphabetic character, followed by zero or more alphanumeric characters including the underscore ("\code{_}"). Case is significant.}
   \item{vartype}{External NetCDF data type as one of the following labels: \code{NC_BYTE}, \code{NC_UBYTE}, \code{NC_CHAR}, \code{NC_SHORT}, \code{NC_USHORT}, \code{NC_INT}, \code{NC_UINT}, \code{NC_INT64}, \code{NC_UINT64}, \code{NC_FLOAT}, \code{NC_DOUBLE}, \code{NC_STRING}, or a user-defined type name.}
   \item{dimensions}{Vector of \code{ndims} dimension IDs or their names corresponding to the variable dimensions or \code{NA} if a scalar variable should be created. If the ID (or name) of the unlimited dimension is included, it must be last.}
+  The following arguments are optional for datasets in "netcdf4" format (and ignored for other formats):
+  \item{chunking}{\code{TRUE} selects chunking, \code{FALSE} implies contiguous storage, \code{NA} allows the NetCDF library to choose a storage layout.}
+  \item{chunksizes}{Chunk size expressed as the number of elements along each dimension, in the same order as \code{dimensions}. If \code{NULL}, the NetCDF library uses a default chunking strategy, which is intended to give reasonable performance in typical applications. Ignored unless \code{chunking} is \code{TRUE}.}
 }
 
 \value{NetCDF variable identifier, returned invisibly.}

--- a/man/var.def.nc.Rd
+++ b/man/var.def.nc.Rd
@@ -8,7 +8,8 @@
 
 \usage{var.def.nc(ncfile, varname, vartype, dimensions,
                   chunking=NA, chunksizes=NULL, deflate=NA, shuffle=FALSE,
-                  big_endian=NA, fletcher32=FALSE)}
+                  big_endian=NA, fletcher32=FALSE,
+                  filter_id=NA, filter_params=integer(0))}
 
 \arguments{
   \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
@@ -22,6 +23,8 @@
   \item{shuffle}{\code{TRUE} to enable byte shuffling, which may improve compression with \code{deflate}.}
   \item{big_endian}{Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for native endianness of the platform.}
   \item{fletcher32}{\code{TRUE} to enable the fletcher32 checksum.}
+  \item{filter_id}{Identifier of filter to associate with the variable, or \code{NA} for no filter. For information about the available filters, please see the NetCDF documentation. Ignored if the installed NetCDF library does not support this feature.}
+  \item{filter_params}{Vector of \code{integer} parameters for the filter specified by \code{filter_id}. The meaning of the parameters depends on the filter implementation, and RNetCDF is unable to perform any validation. Ignored if no filter is defined or if the installed NetCDF library does not support this feature.}
 }
 
 \value{NetCDF variable identifier, returned invisibly.}

--- a/man/var.get.nc.Rd
+++ b/man/var.get.nc.Rd
@@ -7,7 +7,8 @@
 \description{Read the contents of a NetCDF variable.}
 
 \usage{var.get.nc(ncfile, variable, start=NA, count=NA,
-        na.mode=4, collapse=TRUE, unpack=FALSE, rawchar=FALSE, fitnum=FALSE)}
+  na.mode=4, collapse=TRUE, unpack=FALSE, rawchar=FALSE, fitnum=FALSE,
+  cache_bytes=NA, cache_slots=NA, cache_preemption=NA)}
 
 \arguments{
   \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
@@ -31,6 +32,12 @@
     \code{NC_INT64}      \tab \code{\link[bit64]{integer64}} \cr
     \code{NC_UINT64}     \tab \code{\link[bit64]{integer64}} \cr
   }}
+
+The arguments below apply only to datasets in "netcdf4" format. Reading and writing of variables involves a "chunk cache", and default cache settings are defined by the NetCDF library. Performance may be improved in some applications by adjusting the cache settings through the following options:
+
+  \item{cache_bytes}{Size of chunk cache in bytes. Value of \code{NA} (default) implies no change.}
+  \item{cache_slots}{Number of slots in chunk cache. Value of \code{NA} (default) implies no change.}
+  \item{cache_preemption}{Value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read. Value of \code{NA} (default) implies no change.}
 }
 
 \details{

--- a/man/var.inq.nc.Rd
+++ b/man/var.inq.nc.Rd
@@ -25,17 +25,17 @@
 The arguments below apply only to datasets in "netcdf4" format:
 
   \item{chunksizes}{Chunk size expressed as the number of elements along each dimension, in the same order as \code{dimids}. \code{NULL} implies contiguous storage.}
-  \item{cache_bytes}{Size of chunk cache in bytes (\code{NA} if undefined).}
-  \item{cache_slots}{The number of slots in the chunk cache (\code{NA} if undefined).}
-  \item{cache_preemption}{A value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read (\code{NA} if undefined).}
+  \item{cache_bytes}{Size of chunk cache in bytes (\code{NULL} if unsupported).}
+  \item{cache_slots}{The number of slots in the chunk cache (\code{NULL} if unsupported).}
+  \item{cache_preemption}{A value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read (\code{NULL} if unsupported).}
   \item{deflate}{Integer indicating level of compression, from 0 (minimum) to 9 (maximum), or \code{NA} if compression is not enabled.}
   \item{shuffle}{\code{TRUE} if byte shuffling is enabled for the variable, \code{FALSE} otherwise.}
-  \item{big_endian}{Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for not yet determined, or \code{NULL} if the information is not provided by this version of NetCDF.}
+  \item{big_endian}{Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for not yet determined, or \code{NULL} if unsupported.}
   \item{fletcher32}{\code{TRUE} if the fletcher32 checksum is enabled for this variable, \code{FALSE} otherwise.}
-  \item{szip_options}{Integer containing a bitmask of szip options. \code{NA} if szip is not used, or \code{NULL} if the information is not provided by this version of NetCDF.}
-  \item{szip_bits}{Number of bits per pixel for szip. \code{NA} if szip is not used, or \code{NULL} if the information is not provided by this version of NetCDF.}
-  \item{filter_id}{Identifier of filter associated with the variable. \code{NA} if no filter is defined, or \code{NULL} if the information is not provided by this version of NetCDF.}
-  \item{filter_params}{Vector of integer parameters for the filter associated with the variable. \code{NA} if no filter is defined, or \code{NULL} if the information is not provided by this version of NetCDF.}
+  \item{szip_options}{Integer containing a bitmask of szip options. \code{NA} if szip is not used, or \code{NULL} if unsupported.}
+  \item{szip_bits}{Number of bits per pixel for szip. \code{NA} if szip is not used, or \code{NULL} if unsupported.}
+  \item{filter_id}{Identifier of filter associated with the variable. \code{NA} if no filter is defined, or \code{NULL} if unsupported.}
+  \item{filter_params}{Vector of integer parameters for the filter associated with the variable. \code{NA} if no filter is defined, or \code{NULL} if unsupported.}
 }
 
 \details{This function returns information about a NetCDF variable. Information about a variable include its name, its ID, its type, its number of dimensions, a vector of the dimension IDs of this variable and the number of attributes.}

--- a/man/var.inq.nc.Rd
+++ b/man/var.inq.nc.Rd
@@ -34,6 +34,8 @@ The arguments below apply only to datasets in "netcdf4" format:
   \item{fletcher32}{\code{TRUE} if the fletcher32 checksum is enabled for this variable, \code{FALSE} otherwise.}
   \item{szip_options}{Integer containing a bitmask of szip options. \code{NA} if szip is not used, or \code{NULL} if the information is not provided by this version of NetCDF.}
   \item{szip_bits}{Number of bits per pixel for szip. \code{NA} if szip is not used, or \code{NULL} if the information is not provided by this version of NetCDF.}
+  \item{filter_id}{Identifier of filter associated with the variable. \code{NA} if no filter is defined, or \code{NULL} if the information is not provided by this version of NetCDF.}
+  \item{filter_params}{Vector of integer parameters for the filter associated with the variable. \code{NA} if no filter is defined, or \code{NULL} if the information is not provided by this version of NetCDF.}
 }
 
 \details{This function returns information about a NetCDF variable. Information about a variable include its name, its ID, its type, its number of dimensions, a vector of the dimension IDs of this variable and the number of attributes.}

--- a/man/var.inq.nc.Rd
+++ b/man/var.inq.nc.Rd
@@ -31,6 +31,7 @@ The arguments below apply only to datasets in "netcdf4" format:
   \item{deflate}{Integer indicating level of compression, from 0 (minimum) to 9 (maximum), or \code{NA} if compression is not enabled.}
   \item{shuffle}{\code{TRUE} if byte shuffling is enabled for the variable, \code{FALSE} otherwise.}
   \item{big_endian}{Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for not yet determined.}
+  \item{fletcher32}{\code{TRUE} if the fletcher32 checksum is enabled for this variable, \code{FALSE} otherwise.}
 }
 
 \details{This function returns information about a NetCDF variable. Information about a variable include its name, its ID, its type, its number of dimensions, a vector of the dimension IDs of this variable and the number of attributes.}

--- a/man/var.inq.nc.Rd
+++ b/man/var.inq.nc.Rd
@@ -14,21 +14,21 @@
 }
 
 \value{
-  A list containing the following components:
+  A list of named components, some of which are only included for datasets in "netcdf4" format (as indicated by \code{\link[RNetCDF]{file.inq.nc}}).
   \item{id}{Variable ID.}
   \item{name}{Variable name.}
   \item{type}{External NetCDF data type as one of the following labels: \code{NC_BYTE}, \code{NC_UBYTE}, \code{NC_CHAR}, \code{NC_SHORT}, \code{NC_USHORT}, \code{NC_INT}, \code{NC_UINT}, \code{NC_INT64}, \code{NC_UINT64}, \code{NC_FLOAT}, \code{NC_DOUBLE}, \code{NC_STRING}, or a user-defined type name.}
   \item{ndims}{Number of dimensions the variable was defined as using.}
   \item{dimids}{Vector of dimension IDs corresponding to the variable dimensions (\code{NA} for scalar variables). Order is leftmost varying fastest.}
   \item{natts}{Number of variable attributes assigned to this variable.}
-  \item{chunksizes}{Chunk size expressed as the number of elements along each dimension. (\code{NULL} for contiguous storage, \code{NA} for scalar variables). Order is the same as \code{dimids}.}
+  \item{chunksizes}{("netcdf4" only) Chunk size expressed as the number of elements along each dimension, in the same order as \code{dimids}. \code{NULL} implies contiguous storage.}
 }
 
 \details{This function returns information about a NetCDF variable. Information about a variable include its name, its ID, its type, its number of dimensions, a vector of the dimension IDs of this variable and the number of attributes.}
 
 \references{\url{http://www.unidata.ucar.edu/software/netcdf/}}
 
-\author{Pavel Michna}
+\author{Pavel Michna, Milton Woods}
 
 \examples{
 ##  Create a new NetCDF dataset and define two dimensions

--- a/man/var.inq.nc.Rd
+++ b/man/var.inq.nc.Rd
@@ -28,6 +28,8 @@ The arguments below apply only to datasets in "netcdf4" format:
   \item{cache_bytes}{Size of chunk cache in bytes (\code{NA} if undefined).}
   \item{cache_slots}{The number of slots in the chunk cache (\code{NA} if undefined).}
   \item{cache_preemption}{A value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read (\code{NA} if undefined).}
+  \item{deflate}{Integer indicating level of compression, from 0 (minimum) to 9 (maximum), or \code{NA} if compression is not enabled.}
+  \item{shuffle}{\code{TRUE} if byte shuffling is enabled for the variable, \code{FALSE} otherwise.}
 }
 
 \details{This function returns information about a NetCDF variable. Information about a variable include its name, its ID, its type, its number of dimensions, a vector of the dimension IDs of this variable and the number of attributes.}

--- a/man/var.inq.nc.Rd
+++ b/man/var.inq.nc.Rd
@@ -30,7 +30,7 @@ The arguments below apply only to datasets in "netcdf4" format:
   \item{cache_preemption}{A value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read (\code{NA} if undefined).}
   \item{deflate}{Integer indicating level of compression, from 0 (minimum) to 9 (maximum), or \code{NA} if compression is not enabled.}
   \item{shuffle}{\code{TRUE} if byte shuffling is enabled for the variable, \code{FALSE} otherwise.}
-  \item{big_endian}{Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for not yet determined.}
+  \item{big_endian}{Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for not yet determined, or \code{NULL} if the information is not provided by this version of NetCDF.}
   \item{fletcher32}{\code{TRUE} if the fletcher32 checksum is enabled for this variable, \code{FALSE} otherwise.}
   \item{szip_options}{Integer containing a bitmask of szip options. \code{NA} if szip is not used, or \code{NULL} if the information is not provided by this version of NetCDF.}
   \item{szip_bits}{Number of bits per pixel for szip. \code{NA} if szip is not used, or \code{NULL} if the information is not provided by this version of NetCDF.}

--- a/man/var.inq.nc.Rd
+++ b/man/var.inq.nc.Rd
@@ -30,6 +30,7 @@ The arguments below apply only to datasets in "netcdf4" format:
   \item{cache_preemption}{A value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read (\code{NA} if undefined).}
   \item{deflate}{Integer indicating level of compression, from 0 (minimum) to 9 (maximum), or \code{NA} if compression is not enabled.}
   \item{shuffle}{\code{TRUE} if byte shuffling is enabled for the variable, \code{FALSE} otherwise.}
+  \item{big_endian}{Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for not yet determined.}
 }
 
 \details{This function returns information about a NetCDF variable. Information about a variable include its name, its ID, its type, its number of dimensions, a vector of the dimension IDs of this variable and the number of attributes.}

--- a/man/var.inq.nc.Rd
+++ b/man/var.inq.nc.Rd
@@ -32,6 +32,8 @@ The arguments below apply only to datasets in "netcdf4" format:
   \item{shuffle}{\code{TRUE} if byte shuffling is enabled for the variable, \code{FALSE} otherwise.}
   \item{big_endian}{Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for not yet determined.}
   \item{fletcher32}{\code{TRUE} if the fletcher32 checksum is enabled for this variable, \code{FALSE} otherwise.}
+  \item{szip_options}{Integer containing a bitmask of szip options. \code{NA} if szip is not used, or \code{NULL} if the information is not provided by this version of NetCDF.}
+  \item{szip_bits}{Number of bits per pixel for szip. \code{NA} if szip is not used, or \code{NULL} if the information is not provided by this version of NetCDF.}
 }
 
 \details{This function returns information about a NetCDF variable. Information about a variable include its name, its ID, its type, its number of dimensions, a vector of the dimension IDs of this variable and the number of attributes.}

--- a/man/var.inq.nc.Rd
+++ b/man/var.inq.nc.Rd
@@ -21,6 +21,7 @@
   \item{ndims}{Number of dimensions the variable was defined as using.}
   \item{dimids}{Vector of dimension IDs corresponding to the variable dimensions (\code{NA} for scalar variables). Order is leftmost varying fastest.}
   \item{natts}{Number of variable attributes assigned to this variable.}
+  \item{chunksizes}{Chunk size expressed as the number of elements along each dimension. (\code{NULL} for contiguous storage, \code{NA} for scalar variables). Order is the same as \code{dimids}.}
 }
 
 \details{This function returns information about a NetCDF variable. Information about a variable include its name, its ID, its type, its number of dimensions, a vector of the dimension IDs of this variable and the number of attributes.}

--- a/man/var.inq.nc.Rd
+++ b/man/var.inq.nc.Rd
@@ -21,7 +21,13 @@
   \item{ndims}{Number of dimensions the variable was defined as using.}
   \item{dimids}{Vector of dimension IDs corresponding to the variable dimensions (\code{NA} for scalar variables). Order is leftmost varying fastest.}
   \item{natts}{Number of variable attributes assigned to this variable.}
-  \item{chunksizes}{("netcdf4" only) Chunk size expressed as the number of elements along each dimension, in the same order as \code{dimids}. \code{NULL} implies contiguous storage.}
+
+The arguments below apply only to datasets in "netcdf4" format:
+
+  \item{chunksizes}{Chunk size expressed as the number of elements along each dimension, in the same order as \code{dimids}. \code{NULL} implies contiguous storage.}
+  \item{cache_bytes}{Size of chunk cache in bytes (\code{NA} if undefined).}
+  \item{cache_slots}{The number of slots in the chunk cache (\code{NA} if undefined).}
+  \item{cache_preemption}{A value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read (\code{NA} if undefined).}
 }
 
 \details{This function returns information about a NetCDF variable. Information about a variable include its name, its ID, its type, its number of dimensions, a vector of the dimension IDs of this variable and the number of attributes.}

--- a/man/var.put.nc.Rd
+++ b/man/var.put.nc.Rd
@@ -6,7 +6,8 @@
 
 \description{Write the contents of a NetCDF variable.}
 
-\usage{var.put.nc(ncfile, variable, data, start=NA, count=NA, na.mode=4, pack=FALSE)}
+\usage{var.put.nc(ncfile, variable, data, start=NA, count=NA, na.mode=4, pack=FALSE,
+  cache_bytes=NA, cache_slots=NA, cache_preemption=NA)}
 
 \arguments{
   \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
@@ -16,6 +17,12 @@
   \item{count}{A vector of integers specifying the number of values to write along each dimension of \code{variable}. The order of dimensions is the same as for \code{start}. By default (\code{count=NA}), \code{count} is set to \code{dim(data)} for an array or \code{length(data)} for a vector. Otherwise, \code{count} must be a vector whose length is not less than the number of dimensions in \code{variable} (excess elements are ignored). Any \code{NA} value in vector \code{count} indicates that the corresponding dimension should be written from the \code{start} index to the end of the dimension. Note that an unlimited dimension initially has zero length, and the dimension is extended by setting the corresponding element of \code{count} greater than the current length.}
   \item{na.mode}{Set the mode for handling missing values (\code{NA}) in numeric variables: 0=accept \code{_FillValue}, then \code{missing_value} attribute; 1=accept only \code{_FillValue} attribute; 2=accept only \code{missing_value} attribute; 3=no missing value conversion; 4=valid range from valid_min and valid_max or valid_range, fill value from _FillValue, with defaults for each type except \code{NC_BYTE} and \code{NC_UBYTE} (see \url{http://www.unidata.ucar.edu/software/netcdf/docs/attribute_conventions.html}).}
   \item{pack}{Variables are packed if \code{pack=TRUE} and the attributes \code{add_offset} and \code{scale_factor} are defined. Default is \code{FALSE}.}
+
+The arguments below apply only to datasets in "netcdf4" format. Reading and writing of variables involves a "chunk cache", and default cache settings are defined by the NetCDF library. Performance may be improved in some applications by adjusting the cache settings through the following options:
+
+  \item{cache_bytes}{Size of chunk cache in bytes. Value of \code{NA} (default) implies no change.}
+  \item{cache_slots}{Number of slots in chunk cache. Value of \code{NA} (default) implies no change.}
+  \item{cache_preemption}{Value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read. Value of \code{NA} (default) implies no change.}
 }
 
 \details{This function writes values to a NetCDF variable. Data values in R are automatically converted to the correct type of NetCDF variable.

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,6 +1,10 @@
 VERSION=4.4.1.1-dap
 PKG_CPPFLAGS = -I../windows/netcdf-${VERSION}/include \
-	-DHAVE_LIBUDUNITS2 -DHAVE_UDUNITS2_H -DHAVE_DECL_NC_RENAME_GRP=1
+	-DHAVE_LIBUDUNITS2 -DHAVE_UDUNITS2_H \
+	-DHAVE_DECL_NC_RENAME_GRP=1 \
+	-DHAVE_DECL_NC_GET_VAR_CHUNK_CACHE=1 \
+	-DHAVE_DECL_NC_INQ_VAR_SZIP=1 \
+	-DHAVE_DECL_NC_INQ_VAR_FILTER=0
 
 PKG_LIBS = -L../windows/netcdf-${VERSION}/lib${R_ARCH} \
 	-lnetcdf -lcurl -lhdf5_hl -lhdf5 -ludunits2 -lexpat -lszip -lz \

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,10 +1,10 @@
 VERSION=4.4.1.1-dap
 PKG_CPPFLAGS = -I../windows/netcdf-${VERSION}/include \
 	-DHAVE_LIBUDUNITS2 -DHAVE_UDUNITS2_H \
-	-DHAVE_DECL_NC_RENAME_GRP=1 \
-	-DHAVE_DECL_NC_GET_VAR_CHUNK_CACHE=1 \
-	-DHAVE_DECL_NC_INQ_VAR_SZIP=1 \
-	-DHAVE_DECL_NC_INQ_VAR_FILTER=0
+	-DHAVE_NC_RENAME_GRP \
+	-DHAVE_NC_GET_VAR_CHUNK_CACHE \
+	-DHAVE_NC_INQ_VAR_SZIP \
+	-DHAVE_NC_INQ_VAR_ENDIAN \
 
 PKG_LIBS = -L../windows/netcdf-${VERSION}/lib${R_ARCH} \
 	-lnetcdf -lcurl -lhdf5_hl -lhdf5 -ludunits2 -lexpat -lszip -lz \

--- a/src/RNetCDF.h
+++ b/src/RNetCDF.h
@@ -151,7 +151,7 @@ R_nc_utterm ();
 
 SEXP
 R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
-              SEXP chunking, SEXP chunksizes);
+              SEXP chunking, SEXP chunksizes, SEXP deflate, SEXP shuffle);
 
 SEXP
 R_nc_get_var (SEXP nc, SEXP var, SEXP start, SEXP count,

--- a/src/RNetCDF.h
+++ b/src/RNetCDF.h
@@ -151,7 +151,8 @@ R_nc_utterm ();
 
 SEXP
 R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
-              SEXP chunking, SEXP chunksizes, SEXP deflate, SEXP shuffle);
+              SEXP chunking, SEXP chunksizes, SEXP deflate, SEXP shuffle,
+              SEXP big_endian);
 
 SEXP
 R_nc_get_var (SEXP nc, SEXP var, SEXP start, SEXP count,

--- a/src/RNetCDF.h
+++ b/src/RNetCDF.h
@@ -152,7 +152,8 @@ R_nc_utterm ();
 SEXP
 R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
               SEXP chunking, SEXP chunksizes, SEXP deflate, SEXP shuffle,
-              SEXP big_endian, SEXP fletcher32);
+              SEXP big_endian, SEXP fletcher32, SEXP filter_id,
+              SEXP filter_params);
 
 SEXP
 R_nc_get_var (SEXP nc, SEXP var, SEXP start, SEXP count,

--- a/src/RNetCDF.h
+++ b/src/RNetCDF.h
@@ -152,7 +152,7 @@ R_nc_utterm ();
 SEXP
 R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
               SEXP chunking, SEXP chunksizes, SEXP deflate, SEXP shuffle,
-              SEXP big_endian);
+              SEXP big_endian, SEXP fletcher32);
 
 SEXP
 R_nc_get_var (SEXP nc, SEXP var, SEXP start, SEXP count,

--- a/src/RNetCDF.h
+++ b/src/RNetCDF.h
@@ -155,14 +155,16 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
 
 SEXP
 R_nc_get_var (SEXP nc, SEXP var, SEXP start, SEXP count,
-              SEXP rawchar, SEXP fitnum, SEXP namode, SEXP unpack);
+              SEXP rawchar, SEXP fitnum, SEXP namode, SEXP unpack,
+              SEXP cache_bytes, SEXP cache_slots, SEXP cache_preemption);
 
 SEXP
 R_nc_inq_var (SEXP nc, SEXP var);
 
 SEXP
 R_nc_put_var (SEXP nc, SEXP var, SEXP start, SEXP count, SEXP data,
-              SEXP namode, SEXP pack);
+              SEXP namode, SEXP pack,
+              SEXP cache_bytes, SEXP cache_slots, SEXP cache_preemption);
 
 SEXP
 R_nc_rename_var (SEXP nc, SEXP var, SEXP newname);

--- a/src/RNetCDF.h
+++ b/src/RNetCDF.h
@@ -150,7 +150,8 @@ R_nc_utterm ();
 /* Variables */
 
 SEXP
-R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims);
+R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
+              SEXP chunking, SEXP chunksizes);
 
 SEXP
 R_nc_get_var (SEXP nc, SEXP var, SEXP start, SEXP count,

--- a/src/group.c
+++ b/src/group.c
@@ -212,7 +212,7 @@ R_nc_inq_dimids (SEXP nc, SEXP ancestors)
 SEXP
 R_nc_rename_grp (SEXP nc, SEXP grpname)
 {
-#if defined HAVE_DECL_NC_RENAME_GRP && HAVE_DECL_NC_RENAME_GRP
+#ifdef HAVE_NC_RENAME_GRP
   int ncid;
   const char *cgrpname;
 

--- a/src/init.c
+++ b/src/init.c
@@ -68,7 +68,7 @@ static const R_CallMethodDef callMethods[]  = {
   {"R_nc_utinit", (DL_FUNC) &R_nc_utinit, 1},
   {"R_nc_inv_calendar", (DL_FUNC) &R_nc_inv_calendar, 2},
   {"R_nc_utterm", (DL_FUNC) &R_nc_utterm, 0},
-  {"R_nc_def_var", (DL_FUNC) &R_nc_def_var, 6},
+  {"R_nc_def_var", (DL_FUNC) &R_nc_def_var, 8},
   {"R_nc_get_var", (DL_FUNC) &R_nc_get_var, 11},
   {"R_nc_inq_var", (DL_FUNC) &R_nc_inq_var, 2},
   {"R_nc_put_var", (DL_FUNC) &R_nc_put_var, 10},

--- a/src/init.c
+++ b/src/init.c
@@ -68,7 +68,7 @@ static const R_CallMethodDef callMethods[]  = {
   {"R_nc_utinit", (DL_FUNC) &R_nc_utinit, 1},
   {"R_nc_inv_calendar", (DL_FUNC) &R_nc_inv_calendar, 2},
   {"R_nc_utterm", (DL_FUNC) &R_nc_utterm, 0},
-  {"R_nc_def_var", (DL_FUNC) &R_nc_def_var, 10},
+  {"R_nc_def_var", (DL_FUNC) &R_nc_def_var, 12},
   {"R_nc_get_var", (DL_FUNC) &R_nc_get_var, 11},
   {"R_nc_inq_var", (DL_FUNC) &R_nc_inq_var, 2},
   {"R_nc_put_var", (DL_FUNC) &R_nc_put_var, 10},

--- a/src/init.c
+++ b/src/init.c
@@ -69,9 +69,9 @@ static const R_CallMethodDef callMethods[]  = {
   {"R_nc_inv_calendar", (DL_FUNC) &R_nc_inv_calendar, 2},
   {"R_nc_utterm", (DL_FUNC) &R_nc_utterm, 0},
   {"R_nc_def_var", (DL_FUNC) &R_nc_def_var, 6},
-  {"R_nc_get_var", (DL_FUNC) &R_nc_get_var, 8},
+  {"R_nc_get_var", (DL_FUNC) &R_nc_get_var, 11},
   {"R_nc_inq_var", (DL_FUNC) &R_nc_inq_var, 2},
-  {"R_nc_put_var", (DL_FUNC) &R_nc_put_var, 7},
+  {"R_nc_put_var", (DL_FUNC) &R_nc_put_var, 10},
   {"R_nc_rename_var", (DL_FUNC) &R_nc_rename_var, 3},
   {NULL, NULL, 0}
 };

--- a/src/init.c
+++ b/src/init.c
@@ -68,7 +68,7 @@ static const R_CallMethodDef callMethods[]  = {
   {"R_nc_utinit", (DL_FUNC) &R_nc_utinit, 1},
   {"R_nc_inv_calendar", (DL_FUNC) &R_nc_inv_calendar, 2},
   {"R_nc_utterm", (DL_FUNC) &R_nc_utterm, 0},
-  {"R_nc_def_var", (DL_FUNC) &R_nc_def_var, 4},
+  {"R_nc_def_var", (DL_FUNC) &R_nc_def_var, 6},
   {"R_nc_get_var", (DL_FUNC) &R_nc_get_var, 8},
   {"R_nc_inq_var", (DL_FUNC) &R_nc_inq_var, 2},
   {"R_nc_put_var", (DL_FUNC) &R_nc_put_var, 7},

--- a/src/init.c
+++ b/src/init.c
@@ -68,7 +68,7 @@ static const R_CallMethodDef callMethods[]  = {
   {"R_nc_utinit", (DL_FUNC) &R_nc_utinit, 1},
   {"R_nc_inv_calendar", (DL_FUNC) &R_nc_inv_calendar, 2},
   {"R_nc_utterm", (DL_FUNC) &R_nc_utterm, 0},
-  {"R_nc_def_var", (DL_FUNC) &R_nc_def_var, 8},
+  {"R_nc_def_var", (DL_FUNC) &R_nc_def_var, 9},
   {"R_nc_get_var", (DL_FUNC) &R_nc_get_var, 11},
   {"R_nc_inq_var", (DL_FUNC) &R_nc_inq_var, 2},
   {"R_nc_put_var", (DL_FUNC) &R_nc_put_var, 10},

--- a/src/init.c
+++ b/src/init.c
@@ -68,7 +68,7 @@ static const R_CallMethodDef callMethods[]  = {
   {"R_nc_utinit", (DL_FUNC) &R_nc_utinit, 1},
   {"R_nc_inv_calendar", (DL_FUNC) &R_nc_inv_calendar, 2},
   {"R_nc_utterm", (DL_FUNC) &R_nc_utterm, 0},
-  {"R_nc_def_var", (DL_FUNC) &R_nc_def_var, 9},
+  {"R_nc_def_var", (DL_FUNC) &R_nc_def_var, 10},
   {"R_nc_get_var", (DL_FUNC) &R_nc_get_var, 11},
   {"R_nc_inq_var", (DL_FUNC) &R_nc_inq_var, 2},
   {"R_nc_put_var", (DL_FUNC) &R_nc_put_var, 10},

--- a/src/variable.c
+++ b/src/variable.c
@@ -420,7 +420,7 @@ R_nc_get_var (SEXP nc, SEXP var, SEXP start, SEXP count,
   isunpack = (asLogical (unpack) == TRUE);
 
   /*-- Chunk cache options for netcdf4 files ----------------------------------*/
-#if defined HAVE_DECL_NC_GET_VAR_CHUNK_CACHE
+#if defined HAVE_DECL_NC_GET_VAR_CHUNK_CACHE && HAVE_DECL_NC_GET_VAR_CHUNK_CACHE
   if (nc_get_var_chunk_cache(ncid, varid,
                              &bytes, &slots, &preemption) == NC_NOERR) {
     bytes_in = asReal (cache_bytes);
@@ -534,7 +534,7 @@ R_nc_inq_var (SEXP nc, SEXP var)
 	}
       }
 
-#if defined HAVE_DECL_NC_GET_VAR_CHUNK_CACHE
+#if defined HAVE_DECL_NC_GET_VAR_CHUNK_CACHE && HAVE_DECL_NC_GET_VAR_CHUNK_CACHE
       R_nc_check (nc_get_var_chunk_cache (ncid, varid, &cache_bytes,
                                           &cache_slots, &cache_preemption));
       rbytes = R_nc_protect (ScalarReal (cache_bytes));
@@ -584,7 +584,7 @@ R_nc_inq_var (SEXP nc, SEXP var)
     rfletcher = R_nc_protect (ScalarLogical (fletcher == NC_FLETCHER32));
 
     /* szip */
-#if defined HAVE_DECL_NC_INQ_VAR_SZIP
+#if defined HAVE_DECL_NC_INQ_VAR_SZIP && HAVE_DECL_NC_INQ_VAR_SZIP
     status = nc_inq_var_szip (ncid, varid, &szip_options, &szip_bits);
     if (status == NC_NOERR) {
       rszip_options = R_nc_protect (ScalarInteger (szip_options));
@@ -603,7 +603,7 @@ R_nc_inq_var (SEXP nc, SEXP var)
 #endif
 
     /* filter */
-#if defined HAVE_DECL_NC_INQ_VAR_FILTER
+#if defined HAVE_DECL_NC_INQ_VAR_FILTER && HAVE_DECL_NC_INQ_VAR_FILTER
     status = nc_inq_var_filter (ncid, varid,
                                 (unsigned int *) &filter_id,
                                 &filter_nparams, NULL);
@@ -691,7 +691,7 @@ R_nc_put_var (SEXP nc, SEXP var, SEXP start, SEXP count, SEXP data,
   ispack = (asLogical (pack) == TRUE);
 
   /*-- Chunk cache options for netcdf4 files ----------------------------------*/
-#if defined HAVE_DECL_NC_GET_VAR_CHUNK_CACHE
+#if defined HAVE_DECL_NC_GET_VAR_CHUNK_CACHE && HAVE_DECL_NC_GET_VAR_CHUNK_CACHE
   if (nc_get_var_chunk_cache(ncid, varid,
                              &bytes, &slots, &preemption) == NC_NOERR) {
     bytes_in = asReal (cache_bytes);

--- a/src/variable.c
+++ b/src/variable.c
@@ -589,9 +589,11 @@ R_nc_inq_var (SEXP nc, SEXP var)
     if (status == NC_NOERR) {
       rszip_options = R_nc_protect (ScalarInteger (szip_options));
       rszip_bits = R_nc_protect (ScalarInteger (szip_bits));
+#  if defined NC_EFILTER
     } else if (status == NC_EFILTER) {
       rszip_options = R_nc_protect (ScalarInteger (NA_INTEGER));
       rszip_bits = R_nc_protect (ScalarInteger (NA_INTEGER));
+#  endif
     } else {
       R_nc_check (status);
     }

--- a/src/variable.c
+++ b/src/variable.c
@@ -55,10 +55,10 @@
 SEXP
 R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
               SEXP chunking, SEXP chunksizes, SEXP deflate, SEXP shuffle,
-              SEXP big_endian)
+              SEXP big_endian, SEXP fletcher32)
 {
   int ncid, ii, jj, *dimids, ndims, varid, chunkmode, format, withnc4;
-  int deflate_mode, deflate_level, shuffle_mode, endian_mode;
+  int deflate_mode, deflate_level, shuffle_mode, endian_mode, fletcher_mode;
   size_t *chunksize_t;
   nc_type xtype;
   const char *varnamep;
@@ -113,6 +113,7 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
       break;
     }
 
+    fletcher_mode = (asLogical (fletcher32) == TRUE);
   }
 
   /*-- Enter define mode ------------------------------------------------------*/
@@ -136,6 +137,10 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
 
     if (endian_mode != NC_ENDIAN_NATIVE) {
       R_nc_check (nc_def_var_endian (ncid, varid, endian_mode));
+    }
+
+    if (fletcher_mode) {
+      R_nc_check (nc_def_var_fletcher32 (ncid, varid, fletcher_mode));
     }
   }
 

--- a/src/variable.c
+++ b/src/variable.c
@@ -593,9 +593,9 @@ R_nc_inq_var (SEXP nc, SEXP var)
       rslots = R_nc_protect (ScalarReal (cache_slots));
       rpreempt = R_nc_protect (ScalarReal (cache_preemption));
 #else
-      rbytes = R_nc_protect (ScalarReal (NA_REAL));
-      rslots = R_nc_protect (ScalarReal (NA_REAL));
-      rpreempt = R_nc_protect (ScalarReal (NA_REAL));
+      rbytes = R_NilValue;
+      rslots = R_NilValue;
+      rpreempt = R_NilValue;
 #endif
     }
 

--- a/src/variable.c
+++ b/src/variable.c
@@ -652,6 +652,7 @@ R_nc_inq_var (SEXP nc, SEXP var)
 #  endif
     } else {
       R_nc_check (status);
+      return R_NilValue;
     }
 #else
     rszip_options = R_NilValue;
@@ -675,12 +676,22 @@ R_nc_inq_var (SEXP nc, SEXP var)
       rfilter_params = R_nc_protect (ScalarInteger (NA_INTEGER));
     } else {
       R_nc_check (status);
+      return R_NilValue;
     }
 #else
     rfilter_id = R_NilValue;
     rfilter_params = R_NilValue;
 #endif
 
+  } else {
+    rdeflate = R_NilValue;
+    rshuffle = R_NilValue;
+    rendian = R_NilValue;
+    rfletcher = R_NilValue;
+    rszip_bits = R_NilValue;
+    rszip_options = R_NilValue;
+    rfilter_id = R_NilValue;
+    rfilter_params = R_NilValue;
   }
 
   /*-- Convert nc_type to char ------------------------------------------------*/

--- a/src/variable.c
+++ b/src/variable.c
@@ -54,10 +54,11 @@
 
 SEXP
 R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
-              SEXP chunking, SEXP chunksizes, SEXP deflate, SEXP shuffle)
+              SEXP chunking, SEXP chunksizes, SEXP deflate, SEXP shuffle,
+              SEXP big_endian)
 {
   int ncid, ii, jj, *dimids, ndims, varid, chunkmode, format, withnc4;
-  int deflate_mode, deflate_level, shuffle_mode;
+  int deflate_mode, deflate_level, shuffle_mode, endian_mode;
   size_t *chunksize_t;
   nc_type xtype;
   const char *varnamep;
@@ -99,6 +100,19 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
     deflate_mode = (deflate_level != NA_INTEGER);
 
     shuffle_mode = (asLogical (shuffle) == TRUE);
+
+    switch (asLogical (big_endian)) {
+    case TRUE:
+      endian_mode = NC_ENDIAN_BIG;
+      break;
+    case FALSE:
+      endian_mode = NC_ENDIAN_LITTLE;
+      break;
+    default:
+      endian_mode = NC_ENDIAN_NATIVE;
+      break;
+    }
+
   }
 
   /*-- Enter define mode ------------------------------------------------------*/
@@ -118,6 +132,10 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
     if (deflate_mode || shuffle_mode) {
       R_nc_check (nc_def_var_deflate (ncid, varid, shuffle_mode,
                                       deflate_mode, deflate_level));
+    }
+
+    if (endian_mode != NC_ENDIAN_NATIVE) {
+      R_nc_check (nc_def_var_endian (ncid, varid, endian_mode));
     }
   }
 

--- a/src/variable.c
+++ b/src/variable.c
@@ -488,14 +488,14 @@ SEXP
 R_nc_inq_var (SEXP nc, SEXP var)
 {
   int ncid, varid, idim, ndims, natts, *dimids, storeprop, format, withnc4;
-  int shuffle, deflate, deflate_level, endian;
+  int shuffle, deflate, deflate_level, endian, fletcher;
   size_t *chunksize_t, cache_bytes, cache_slots;
   float cache_preemption;
   double *chunkdbl;
   char varname[NC_MAX_NAME + 1], vartype[NC_MAX_NAME+1];
   nc_type xtype;
   SEXP result, rdimids, rchunks, rbytes, rslots, rpreempt,
-       rshuffle, rdeflate, rendian;
+       rshuffle, rdeflate, rendian, rfletcher;
 
   /*-- Convert arguments to netcdf ids ----------------------------------------*/
   ncid = asInteger (nc);
@@ -574,6 +574,10 @@ R_nc_inq_var (SEXP nc, SEXP var)
     } else {
       rendian = R_nc_protect (ScalarLogical (NA_LOGICAL));
     }
+
+    /* fletcher32 */
+    R_nc_check (nc_inq_var_fletcher32 (ncid, varid, &fletcher));
+    rfletcher = R_nc_protect (ScalarLogical (fletcher == NC_FLETCHER32));
   }
 
   /*-- Convert nc_type to char ------------------------------------------------*/
@@ -581,7 +585,7 @@ R_nc_inq_var (SEXP nc, SEXP var)
 
   /*-- Construct the output list ----------------------------------------------*/
   if (withnc4) {
-    result = R_nc_protect (allocVector (VECSXP, 13));
+    result = R_nc_protect (allocVector (VECSXP, 14));
   } else {
     result = R_nc_protect (allocVector (VECSXP, 6));
   }
@@ -601,6 +605,7 @@ R_nc_inq_var (SEXP nc, SEXP var)
     SET_VECTOR_ELT (result, 10, rdeflate);
     SET_VECTOR_ELT (result, 11, rshuffle);
     SET_VECTOR_ELT (result, 12, rendian);
+    SET_VECTOR_ELT (result, 13, rfletcher);
   }
 
   RRETURN(result);

--- a/src/variable.c
+++ b/src/variable.c
@@ -103,6 +103,7 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
 
     shuffle_mode = (asLogical (shuffle) == TRUE);
 
+#ifdef HAVE_NC_INQ_VAR_ENDIAN
     switch (asLogical (big_endian)) {
     case TRUE:
       endian_mode = NC_ENDIAN_BIG;
@@ -114,6 +115,7 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
       endian_mode = NC_ENDIAN_NATIVE;
       break;
     }
+#endif
 
     fletcher_mode = (asLogical (fletcher32) == TRUE);
 
@@ -141,15 +143,17 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
                                       deflate_mode, deflate_level));
     }
 
+#ifdef HAVE_NC_INQ_VAR_ENDIAN
     if (endian_mode != NC_ENDIAN_NATIVE) {
       R_nc_check (nc_def_var_endian (ncid, varid, endian_mode));
     }
+#endif
 
     if (fletcher_mode) {
       R_nc_check (nc_def_var_fletcher32 (ncid, varid, fletcher_mode));
     }
 
-#if defined HAVE_DECL_NC_INQ_VAR_FILTER && HAVE_DECL_NC_INQ_VAR_FILTER
+#ifdef HAVE_NC_INQ_VAR_FILTER
     if (filter_mode) {
       R_nc_check (nc_def_var_filter (ncid, varid, (unsigned int) filtid,
         xlength (filter_params), (const unsigned int*) filtparm));
@@ -468,7 +472,7 @@ R_nc_get_var (SEXP nc, SEXP var, SEXP start, SEXP count,
   isunpack = (asLogical (unpack) == TRUE);
 
   /*-- Chunk cache options for netcdf4 files ----------------------------------*/
-#if defined HAVE_DECL_NC_GET_VAR_CHUNK_CACHE && HAVE_DECL_NC_GET_VAR_CHUNK_CACHE
+#ifdef HAVE_NC_GET_VAR_CHUNK_CACHE
   if (nc_get_var_chunk_cache(ncid, varid,
                              &bytes, &slots, &preemption) == NC_NOERR) {
     bytes_in = asReal (cache_bytes);
@@ -582,7 +586,7 @@ R_nc_inq_var (SEXP nc, SEXP var)
 	}
       }
 
-#if defined HAVE_DECL_NC_GET_VAR_CHUNK_CACHE && HAVE_DECL_NC_GET_VAR_CHUNK_CACHE
+#ifdef HAVE_NC_GET_VAR_CHUNK_CACHE
       R_nc_check (nc_get_var_chunk_cache (ncid, varid, &cache_bytes,
                                           &cache_slots, &cache_preemption));
       rbytes = R_nc_protect (ScalarReal (cache_bytes));
@@ -618,6 +622,7 @@ R_nc_inq_var (SEXP nc, SEXP var)
     rshuffle = R_nc_protect (ScalarLogical (shuffle));
 
     /* endian */
+#ifdef HAVE_NC_INQ_VAR_ENDIAN
     R_nc_check (nc_inq_var_endian (ncid, varid, &endian));
     if (endian == NC_ENDIAN_LITTLE) {
       rendian = R_nc_protect (ScalarLogical (0));
@@ -626,13 +631,16 @@ R_nc_inq_var (SEXP nc, SEXP var)
     } else {
       rendian = R_nc_protect (ScalarLogical (NA_LOGICAL));
     }
+#else
+    rendian = R_NilValue;
+#endif
 
     /* fletcher32 */
     R_nc_check (nc_inq_var_fletcher32 (ncid, varid, &fletcher));
     rfletcher = R_nc_protect (ScalarLogical (fletcher == NC_FLETCHER32));
 
     /* szip */
-#if defined HAVE_DECL_NC_INQ_VAR_SZIP && HAVE_DECL_NC_INQ_VAR_SZIP
+#ifdef HAVE_NC_INQ_VAR_SZIP
     status = nc_inq_var_szip (ncid, varid, &szip_options, &szip_bits);
     if (status == NC_NOERR) {
       rszip_options = R_nc_protect (ScalarInteger (szip_options));
@@ -651,7 +659,7 @@ R_nc_inq_var (SEXP nc, SEXP var)
 #endif
 
     /* filter */
-#if defined HAVE_DECL_NC_INQ_VAR_FILTER && HAVE_DECL_NC_INQ_VAR_FILTER
+#ifdef HAVE_NC_INQ_VAR_FILTER
     status = nc_inq_var_filter (ncid, varid,
                                 (unsigned int *) &filter_id,
                                 &filter_nparams, NULL);
@@ -739,7 +747,7 @@ R_nc_put_var (SEXP nc, SEXP var, SEXP start, SEXP count, SEXP data,
   ispack = (asLogical (pack) == TRUE);
 
   /*-- Chunk cache options for netcdf4 files ----------------------------------*/
-#if defined HAVE_DECL_NC_GET_VAR_CHUNK_CACHE && HAVE_DECL_NC_GET_VAR_CHUNK_CACHE
+#ifdef HAVE_NC_GET_VAR_CHUNK_CACHE
   if (nc_get_var_chunk_cache(ncid, varid,
                              &bytes, &slots, &preemption) == NC_NOERR) {
     bytes_in = asReal (cache_bytes);

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -129,7 +129,14 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
 
   ##  Define variables
   var.def.nc(nc, "time", "NC_INT", "time")
-  var.def.nc(nc, "temperature", "NC_DOUBLE", c(0,1))
+
+  inq_temperature <- list()
+  inq_temperature$id <- var.def.nc(nc, "temperature", "NC_DOUBLE", c(0,1))
+  inq_temperature$name <- "temperature"
+  inq_temperature$type <- "NC_DOUBLE"
+  inq_temperature$ndims <- 2
+  inq_temperature$dimids <- c(0,1)
+
   var.def.nc(nc, "packvar", "NC_BYTE", c("station"))
   var.def.nc(nc, "name", "NC_CHAR", c("max_string_length", "station"))
   var.def.nc(nc, "qcflag", "NC_CHAR", c("station"))
@@ -183,6 +190,7 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
 
   ##  Set a _FillValue attribute for temperature
   att.put.nc(nc, "temperature", "_FillValue", "NC_DOUBLE", -99999.9)
+  inq_temperature$natts <- 1
 
   ## Define the packing used by packvar
   id_double <- type.inq.nc(nc, "NC_DOUBLE")$id
@@ -197,9 +205,11 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   att.put.nc(nc, "name", "raw_att", "NC_CHAR", charToRaw(att_text))
   if (format == "netcdf4") {
     att.put.nc(nc, "temperature", "string_att", "NC_STRING", att_text2)
+    inq_temperature$natts <- inq_temperature$natts + 1
     if (has_bit64) {
       hugeint <- as.integer64("-1234567890123456789")
       att.put.nc(nc, "temperature", "int64_att", "NC_INT64", hugeint)
+      inq_temperature$natts <- inq_temperature$natts + 1
     }
   }
 
@@ -465,6 +475,12 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
                      any(numtype==c("NC_BYTE","NC_UBYTE","NC_SHORT","NC_USHORT","NC_INT")),
                      tally)
   }
+
+  cat("Inquire about numeric variable ...")
+  x <- inq_temperature
+  y <- var.inq.nc(nc, "temperature")
+  str(y)
+  tally <- testfun(x,y[1:6])
 
   cat("Read numeric matrix ... ")
   x <- mytemperature

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -131,11 +131,14 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   var.def.nc(nc, "time", "NC_INT", "time")
 
   inq_temperature <- list()
-  inq_temperature$id <- var.def.nc(nc, "temperature", "NC_DOUBLE", c(0,1))
+  inq_temperature$id <- var.def.nc(nc, "temperature", "NC_DOUBLE", c(0,1),
+                                   chunking=TRUE, chunksizes=c(5,1))
   inq_temperature$name <- "temperature"
   inq_temperature$type <- "NC_DOUBLE"
   inq_temperature$ndims <- 2
   inq_temperature$dimids <- c(0,1)
+  inq_temperature$natts <- 0
+  inq_temperature$chunksizes <- c(5,1)
 
   var.def.nc(nc, "packvar", "NC_BYTE", c("station"))
   var.def.nc(nc, "name", "NC_CHAR", c("max_string_length", "station"))
@@ -190,7 +193,7 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
 
   ##  Set a _FillValue attribute for temperature
   att.put.nc(nc, "temperature", "_FillValue", "NC_DOUBLE", -99999.9)
-  inq_temperature$natts <- 1
+  inq_temperature$natts <- inq_temperature$natts + 1
 
   ## Define the packing used by packvar
   id_double <- type.inq.nc(nc, "NC_DOUBLE")$id
@@ -480,7 +483,11 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   x <- inq_temperature
   y <- var.inq.nc(nc, "temperature")
   str(y)
-  tally <- testfun(x,y[1:6])
+  if (format == "netcdf4") {
+    tally <- testfun(x,y[1:7])
+  } else {
+    tally <- testfun(x,y[1:6])
+  }
 
   cat("Read numeric matrix ... ")
   x <- mytemperature

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -137,11 +137,11 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
                                    fletcher32=TRUE)
   inq_temperature$name <- "temperature"
   inq_temperature$type <- "NC_DOUBLE"
-  inq_temperature$ndims <- 2
-  inq_temperature$dimids <- c(0,1)
-  inq_temperature$natts <- 0
-  inq_temperature$chunksizes <- c(5,1)
-  inq_temperature$deflate <- 5
+  inq_temperature$ndims <- as.integer(2)
+  inq_temperature$dimids <- as.integer(c(0,1))
+  inq_temperature$natts <- as.integer(0)
+  inq_temperature$chunksizes <- as.numeric(c(5,1))
+  inq_temperature$deflate <- as.integer(5)
   inq_temperature$shuffle <- TRUE
   inq_temperature$big_endian <- TRUE
   inq_temperature$fletcher32 <- TRUE

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -513,10 +513,16 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   var_inq_names <- c("id", "name", "type", "ndims", "dimids", "natts")
   if (format == "netcdf4") {
     var_inq_names_nc4 <- c(var_inq_names, "chunksizes", "deflate", "shuffle",
-                           "big_endian", "fletcher32")
+                           "fletcher32")
     tally <- testfun(x[var_inq_names_nc4], y[var_inq_names_nc4], tally)
+    big_endian <- y$big_endian
+    # May be NULL or NA for older netcdf libraries, TRUE otherwise.
+    if (!is.null(big_endian) && !isTRUE(is.na(big_endian))) {
+      tally <- testfun(TRUE, big_endian, tally)
+    }
     preempt <- y$cache_preemption
-    if (!is.na(preempt)) {
+    # May be NULL for older netcdf libraries, numeric otherwise.
+    if (!is.null(preempt)) {
       tally <- testfun(0.4, preempt, tally)
     }
   } else {

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -506,7 +506,6 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   cat("Inquire about numeric variable ...")
   x <- inq_temperature
   y <- var.inq.nc(nc, "temperature")
-  str(y)
   var_inq_names <- c("id", "name", "type", "ndims", "dimids", "natts")
   if (format == "netcdf4") {
     var_inq_names_nc4 <- c(var_inq_names, "chunksizes", "deflate", "shuffle",

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -132,13 +132,16 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
 
   inq_temperature <- list()
   inq_temperature$id <- var.def.nc(nc, "temperature", "NC_DOUBLE", c(0,1),
-                                   chunking=TRUE, chunksizes=c(5,1))
+                                   chunking=TRUE, chunksizes=c(5,1),
+                                   deflate=5, shuffle=TRUE)
   inq_temperature$name <- "temperature"
   inq_temperature$type <- "NC_DOUBLE"
   inq_temperature$ndims <- 2
   inq_temperature$dimids <- c(0,1)
   inq_temperature$natts <- 0
   inq_temperature$chunksizes <- c(5,1)
+  inq_temperature$deflate <- 5
+  inq_temperature$shuffle <- TRUE
 
   var.def.nc(nc, "packvar", "NC_BYTE", c("station"))
   var.def.nc(nc, "name", "NC_CHAR", c("max_string_length", "station"))
@@ -501,14 +504,16 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   x <- inq_temperature
   y <- var.inq.nc(nc, "temperature")
   str(y)
+  var_inq_names <- c("id", "name", "type", "ndims", "dimids", "natts")
   if (format == "netcdf4") {
-    tally <- testfun(x,y[1:7])
+    var_inq_names_nc4 <- c(var_inq_names, "chunksizes", "deflate", "shuffle")
+    tally <- testfun(x[var_inq_names_nc4],y[var_inq_names_nc4])
     preempt <- y$cache_preemption
     if (!is.na(preempt)) {
       tally <- testfun(0.4, preempt)
     }
   } else {
-    tally <- testfun(x,y[1:6])
+    tally <- testfun(x[var_inq_names],y[var_inq_names])
   }
 
   cat("Read numeric matrix slice ... ")

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -133,7 +133,7 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   inq_temperature <- list()
   inq_temperature$id <- var.def.nc(nc, "temperature", "NC_DOUBLE", c(0,1),
                                    chunking=TRUE, chunksizes=c(5,1),
-                                   deflate=5, shuffle=TRUE)
+                                   deflate=5, shuffle=TRUE, big_endian=TRUE)
   inq_temperature$name <- "temperature"
   inq_temperature$type <- "NC_DOUBLE"
   inq_temperature$ndims <- 2
@@ -142,6 +142,7 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   inq_temperature$chunksizes <- c(5,1)
   inq_temperature$deflate <- 5
   inq_temperature$shuffle <- TRUE
+  inq_temperature$big_endian <- TRUE
 
   var.def.nc(nc, "packvar", "NC_BYTE", c("station"))
   var.def.nc(nc, "name", "NC_CHAR", c("max_string_length", "station"))
@@ -506,7 +507,8 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   str(y)
   var_inq_names <- c("id", "name", "type", "ndims", "dimids", "natts")
   if (format == "netcdf4") {
-    var_inq_names_nc4 <- c(var_inq_names, "chunksizes", "deflate", "shuffle")
+    var_inq_names_nc4 <- c(var_inq_names, "chunksizes", "deflate", "shuffle",
+                           "big_endian")
     tally <- testfun(x[var_inq_names_nc4],y[var_inq_names_nc4])
     preempt <- y$cache_preemption
     if (!is.na(preempt)) {

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -77,6 +77,10 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   ncfile <- paste("test_", format, ".nc", sep="")
   nc <- create.nc(ncfile, format=format)
 
+  # Show library version:
+  libvers <- file.inq.nc(nc)$libvers
+  cat("Version of netcdf library ... ", libvers, "\n")
+
   nstation <- 5
   ntime <- 2
   nstring <- 32

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -133,7 +133,8 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   inq_temperature <- list()
   inq_temperature$id <- var.def.nc(nc, "temperature", "NC_DOUBLE", c(0,1),
                                    chunking=TRUE, chunksizes=c(5,1),
-                                   deflate=5, shuffle=TRUE, big_endian=TRUE)
+                                   deflate=5, shuffle=TRUE, big_endian=TRUE,
+                                   fletcher32=TRUE)
   inq_temperature$name <- "temperature"
   inq_temperature$type <- "NC_DOUBLE"
   inq_temperature$ndims <- 2
@@ -143,6 +144,7 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   inq_temperature$deflate <- 5
   inq_temperature$shuffle <- TRUE
   inq_temperature$big_endian <- TRUE
+  inq_temperature$fletcher32 <- TRUE
 
   var.def.nc(nc, "packvar", "NC_BYTE", c("station"))
   var.def.nc(nc, "name", "NC_CHAR", c("max_string_length", "station"))
@@ -508,7 +510,7 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   var_inq_names <- c("id", "name", "type", "ndims", "dimids", "natts")
   if (format == "netcdf4") {
     var_inq_names_nc4 <- c(var_inq_names, "chunksizes", "deflate", "shuffle",
-                           "big_endian")
+                           "big_endian", "fletcher32")
     tally <- testfun(x[var_inq_names_nc4],y[var_inq_names_nc4])
     preempt <- y$cache_preemption
     if (!is.na(preempt)) {

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -199,7 +199,7 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
 
   ##  Set a _FillValue attribute for temperature
   att.put.nc(nc, "temperature", "_FillValue", "NC_DOUBLE", -99999.9)
-  inq_temperature$natts <- inq_temperature$natts + 1
+  inq_temperature$natts <- inq_temperature$natts + as.integer(1)
 
   ## Define the packing used by packvar
   id_double <- type.inq.nc(nc, "NC_DOUBLE")$id
@@ -214,11 +214,11 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   att.put.nc(nc, "name", "raw_att", "NC_CHAR", charToRaw(att_text))
   if (format == "netcdf4") {
     att.put.nc(nc, "temperature", "string_att", "NC_STRING", att_text2)
-    inq_temperature$natts <- inq_temperature$natts + 1
+    inq_temperature$natts <- inq_temperature$natts + as.integer(1)
     if (has_bit64) {
       hugeint <- as.integer64("-1234567890123456789")
       att.put.nc(nc, "temperature", "int64_att", "NC_INT64", hugeint)
-      inq_temperature$natts <- inq_temperature$natts + 1
+      inq_temperature$natts <- inq_temperature$natts + as.integer(1)
     }
   }
 

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -511,13 +511,13 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   if (format == "netcdf4") {
     var_inq_names_nc4 <- c(var_inq_names, "chunksizes", "deflate", "shuffle",
                            "big_endian", "fletcher32")
-    tally <- testfun(x[var_inq_names_nc4],y[var_inq_names_nc4])
+    tally <- testfun(x[var_inq_names_nc4], y[var_inq_names_nc4], tally)
     preempt <- y$cache_preemption
     if (!is.na(preempt)) {
-      tally <- testfun(0.4, preempt)
+      tally <- testfun(0.4, preempt, tally)
     }
   } else {
-    tally <- testfun(x[var_inq_names],y[var_inq_names])
+    tally <- testfun(x[var_inq_names], y[var_inq_names], tally)
   }
 
   cat("Read numeric matrix slice ... ")


### PR DESCRIPTION
Netcdf4 provides advanced settings for variables, including chunking, deflation, endianness, checksums and user-defined filters. This PR exposes the advanced settings as optional arguments in functions `var.def.nc` and `var.inq.nc`.

Resolves #32 .