### PR TITLE
Collapse array dimensions with drop()

### DIFF
--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -566,11 +566,7 @@ var.get.nc <- function(ncfile, variable, start = NA, count = NA, na.mode = 4,
 
   #-- Collapse singleton dimensions --------------------------------------
   if (isTRUE(collapse) && !is.null(dim(nc))) {
-    datadim <- dim(nc)
-    keepdim <- (datadim != 1)
-    if (any(keepdim)) {
-      dim(nc) <- datadim[keepdim]
-    }
+    nc <- drop(nc)
   }
 
   return(nc)

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -530,16 +530,20 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   }
 
   cat("Read numeric matrix slice ... ")
+  x <- mytemperature[,2,drop=FALSE]
+  y <- var.get.nc(nc, "temperature", c(NA,2), c(NA,1), collapse=FALSE)
+  tally <- testfun(x,y,tally)
   x <- mytemperature[,2]
-  dim(x) <- length(x)
-  y <- var.get.nc(nc, "temperature", c(NA,2), c(NA,1))
+  y <- var.get.nc(nc, "temperature", c(NA,2), c(NA,1), collapse=TRUE)
   tally <- testfun(x,y,tally)
 
   cat("Read numeric matrix empty slice ... ")
   x <- numeric(0)
   dim(x) <- c(0,1)
-  y <- var.get.nc(nc, "temperature", c(NA,2), c(0,1),collapse=FALSE)
+  y <- var.get.nc(nc, "temperature", c(NA,2), c(0,1), collapse=FALSE)
   tally <- testfun(x,y,tally)
+  y <- var.get.nc(nc, "temperature", c(NA,2), c(0,1), collapse=TRUE)
+  tally <- testfun(drop(x),y,tally)
 
   cat("Read numeric scalar ... ")
   x <- myint0
@@ -580,8 +584,10 @@ for (format in c("classic","offset64","classic4","netcdf4")) {
   cat("Read empty 2D char array ... ")
   x <- character(0)
   dim(x) <- 0
-  y <- var.get.nc(nc, "name", NA, c(0,0),collapse=FALSE)
+  y <- var.get.nc(nc, "name", NA, c(0,0), collapse=FALSE)
   tally <- testfun(x,y,tally)
+  y <- var.get.nc(nc, "name", NA, c(0,0), collapse=TRUE)
+  tally <- testfun(drop(x),y,tally)
 
   cat("Read 1D char slice ... ")
   x <- substring(myqcflag,2,3)


### PR DESCRIPTION
The `collapse` option of `var.get.nc` should behave the same way as the `drop` option in the R indexing operator `[`. However, some edge cases of `collapse` give unexpected results. For example, when all dimensions of an array slice have size 1, `collapse` should remove the dimensions attribute, but the original dimensions are returned instead. The expected behaviour can be enforced by implementing `collapse` with the R builtin function `drop`.