### PR TITLE
Release version 2.0-2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RNetCDF
-Version: 2.0-1
-Date: 2019-09-21
+Version: 2.0-2
+Date: 2019-09-30
 Title: Interface to NetCDF Datasets
 Authors@R: c(person("Pavel", "Michna", role = "aut",
                     email = "rnetcdf-devel@bluewin.ch"),


### PR DESCRIPTION
The version number has been stuck on 2.0-1 almost since the 1.9 branch was cut. The build number is being incremented before release, to distinguish the release from development versions of the package that were installed by some brave and helpful users.