### PR TITLE
Quote software in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Authors@R: c(person("Pavel", "Michna", role = "aut",
 Depends: R (>= 3.0.0)
 SystemRequirements: netcdf udunits-2
 Suggests: bit64
-Description: An interface to the 'NetCDF' file format designed by Unidata
+Description: An interface to the 'NetCDF' file formats designed by Unidata
   for efficient storage of array-oriented scientific data and descriptions.
   Supports most capabilities of 'NetCDF' version 4,
   along with calendar conversions from 'UDUNITS' version 2.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,8 +11,8 @@ SystemRequirements: netcdf udunits-2
 Suggests: bit64
 Description: An interface to the 'NetCDF' file format designed by Unidata
   for efficient storage of array-oriented scientific data and descriptions.
-  This R interface is closely based on the C API of the 'NetCDF4' library,
-  and it includes calendar conversions from the Unidata 'UDUNITS2' library.
+  Supports most capabilities of 'NetCDF' version 4,
+  along with calendar conversions from 'UDUNITS' version 2.
 License: GPL (>= 2) | file LICENSE
 URL: https://github.com/mjwoods/RNetCDF
      http://www.unidata.ucar.edu/software/netcdf/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: RNetCDF
 Version: 2.0-4
 Date: 2019-10-13
-Title: Interface to NetCDF Datasets
+Title: Interface to 'NetCDF' Datasets
 Authors@R: c(person("Pavel", "Michna", role = "aut",
                     email = "rnetcdf-devel@bluewin.ch"),
              person("Milton", "Woods", role = c("aut", "cre"),
@@ -9,10 +9,10 @@ Authors@R: c(person("Pavel", "Michna", role = "aut",
 Depends: R (>= 3.0.0)
 SystemRequirements: netcdf udunits-2
 Suggests: bit64
-Description: An interface to the NetCDF file format designed by Unidata
+Description: An interface to the 'NetCDF' file format designed by Unidata
   for efficient storage of array-oriented scientific data and descriptions.
-  This R interface is closely based on the C API of the NetCDF4 library,
-  and it includes calendar conversions from the Unidata UDUNITS2 library.
+  This R interface is closely based on the C API of the 'NetCDF4' library,
+  and it includes calendar conversions from the Unidata 'UDUNITS2' library.
 License: GPL (>= 2) | file LICENSE
 URL: https://github.com/mjwoods/RNetCDF
      http://www.unidata.ucar.edu/software/netcdf/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,8 +11,8 @@ SystemRequirements: netcdf udunits-2
 Suggests: bit64
 Description: An interface to the 'NetCDF' file formats designed by Unidata
   for efficient storage of array-oriented scientific data and descriptions.
-  Supports most capabilities of 'NetCDF' version 4,
-  along with calendar conversions from 'UDUNITS' version 2.
+  Most capabilities of 'NetCDF' version 4 are supported. Optional conversions
+  of time units are enabled by 'UDUNITS' version 2, also from Unidata.
 License: GPL (>= 2) | file LICENSE
 URL: https://github.com/mjwoods/RNetCDF
      http://www.unidata.ucar.edu/software/netcdf/


### PR DESCRIPTION
Names of external packages are supposed to be wrapped in single quotes, within the Title and Description fields of the DESCRIPTION file.

While fixing the quotes, I took the opportunity to reword the Description, hopefully improving it in the process.