### PR TITLE
Disable automatic conversion of missing values for user-defined types

### DIFF
--- a/src/attribute.c
+++ b/src/attribute.c
@@ -174,7 +174,7 @@ R_nc_get_att (SEXP nc, SEXP var, SEXP att, SEXP rawchar, SEXP fitnum)
 
   /*-- Allocate memory and read attribute from file ---------------------------*/
   buf = R_nc_c2r_init (&io, NULL, ncid, xtype, -1, &cnt,
-                       israw, isfit, NULL, NULL, NULL, NULL, NULL);
+                       israw, isfit, 0, NULL, NULL, NULL, NULL, NULL);
   if (cnt > 0) {
     R_nc_check (nc_get_att (ncid, varid, attname, buf));
   }
@@ -317,7 +317,7 @@ R_nc_put_att (SEXP nc, SEXP var, SEXP att, SEXP type, SEXP data)
 
   /* -- Write attribute to file -----------------------------------------------*/
   if (cnt > 0) {
-    buf = R_nc_r2c (data, ncid, xtype, 1, &cnt, NULL, NULL, NULL);
+    buf = R_nc_r2c (data, ncid, xtype, 1, &cnt, 0, NULL, NULL, NULL);
     R_nc_check (nc_put_att (ncid, varid, attname, xtype, cnt, buf));
   }
 

--- a/src/convert.h
+++ b/src/convert.h
@@ -61,7 +61,7 @@ typedef struct {
   void *cbuf, *rbuf;
   nc_type xtype;
   int ncid, ndim, rawchar, fitnum;
-  size_t *xdim;
+  size_t *xdim, fillsize;
   void *fill, *min, *max;
   double *scale, *add;
   } R_nc_buf;
@@ -78,7 +78,8 @@ typedef struct {
  */
 const void *
 R_nc_r2c (SEXP rv, int ncid, nc_type xtype, int ndim, const size_t *xdim,
-          const void *fill, const double *scale, const double *add);
+          size_t fillsize, const void *fill,
+          const double *scale, const double *add);
 
 
 /* Convert an array of netcdf external type (xtype) to R.
@@ -99,7 +100,7 @@ R_nc_r2c (SEXP rv, int ncid, nc_type xtype, int ndim, const size_t *xdim,
 void * \
 R_nc_c2r_init (R_nc_buf *io, void *cbuf,
                int ncid, nc_type xtype, int ndim, const size_t *xdim,
-               int rawchar, int fitnum,
+               int rawchar, int fitnum, size_t fillsize,
                const void *fill, const void *min, const void *max,
                const double *scale, const double *add);
 

--- a/src/type.c
+++ b/src/type.c
@@ -169,7 +169,7 @@ R_nc_def_enum (int ncid, const char *typename, SEXP basetype,
     R_nc_error ("Lengths of names and values must match");
   }
 
-  cvals = R_nc_r2c (values, ncid, xtype, 1, &nval, NULL, NULL, NULL);
+  cvals = R_nc_r2c (values, ncid, xtype, 1, &nval, 0, NULL, NULL, NULL);
 
   /*-- Enter define mode ------------------------------------------------------*/
   R_nc_check (R_nc_redef (ncid));
@@ -272,7 +272,7 @@ R_nc_insert_type (SEXP nc, SEXP type, SEXP name, SEXP value,
 
   if (class == NC_ENUM) {
     if (!isNull (value)) {
-      tmpval = R_nc_r2c (value, ncid, xtype, 0, NULL, NULL, NULL, NULL);
+      tmpval = R_nc_r2c (value, ncid, xtype, 0, NULL, 0, NULL, NULL, NULL);
     } else {
       RERROR ("No value given for enumerated type");
     }
@@ -413,7 +413,7 @@ R_nc_inq_type (SEXP nc, SEXP type, SEXP fields)
 	/* Read named vector of member values */
 	fieldnames = R_nc_protect (allocVector (STRSXP, nfields));
         cval = R_nc_c2r_init (&io, NULL, ncid, basetype, -1, &nfields,
-                              0, 1, NULL, NULL, NULL, NULL, NULL);
+                              0, 1, 0, NULL, NULL, NULL, NULL, NULL);
 
 	imax = nfields; // netcdf member index is int
 	for (ii=0; ii < imax; ii++, cval+=size) {

--- a/src/variable.c
+++ b/src/variable.c
@@ -519,7 +519,7 @@ R_nc_get_var (SEXP nc, SEXP var, SEXP start, SEXP count,
 
   /*-- Allocate memory and read variable from file ----------------------------*/
   buf = R_nc_c2r_init (&io, NULL, ncid, xtype, ndims, ccount,
-                       israw, isfit, fillp, minp, maxp, scalep, addp);
+                       israw, isfit, fillsize, fillp, minp, maxp, scalep, addp);
 
   if (R_nc_length (ndims, ccount) > 0) {
     R_nc_check (nc_get_vara (ncid, varid, cstart, ccount, buf));
@@ -805,7 +805,8 @@ R_nc_put_var (SEXP nc, SEXP var, SEXP start, SEXP count, SEXP data,
 
   /*-- Write variable to file -------------------------------------------------*/
   if (R_nc_length (ndims, ccount) > 0) {
-    buf = R_nc_r2c (data, ncid, xtype, ndims, ccount, fillp, scalep, addp);
+    buf = R_nc_r2c (data, ncid, xtype, ndims, ccount,
+                    fillsize, fillp, scalep, addp);
     R_nc_check (nc_put_vara (ncid, varid, cstart, ccount, buf));
   }
 

--- a/src/variable.c
+++ b/src/variable.c
@@ -216,19 +216,15 @@ R_nc_miss_att (int ncid, int varid, int mode,
   *min = NULL;
   *max = NULL;
 
-  /* Get details about type of netcdf variable */
+  /* Get details about type and size of netcdf variable */
   R_nc_check (nc_inq_vartype (ncid, varid, &xtype));
-  if (xtype > NC_MAX_ATOMIC_TYPE) {
-    /* Use base type of vlen or enum type */
-    R_nc_check (nc_inq_user_type (ncid, xtype, NULL, NULL, &basetype, NULL, &class));
-    if (class == NC_ENUM || class == NC_VLEN) {
-      xtype = basetype;
-    } else {
-      /* Other user-defined types can be handled by users,
-         based on any convention they choose.
-       */
-      return 0;
-    }
+  if (xtype == NC_CHAR ||
+      xtype == NC_STRING ||
+      xtype > NC_MAX_ATOMIC_TYPE) {
+    /* NetCDF attribute conventions describe the handling of missing values
+       in atomic numeric types. Let users handle other types as needed.
+     */
+    return 0;
   }
   R_nc_check (nc_inq_type (ncid, xtype, NULL, &size));
 
@@ -373,7 +369,7 @@ R_nc_miss_att (int ncid, int varid, int mode,
             **(unsigned long long **) fill = NC_FILL_UINT64;
             break;
           default:
-            return 0;
+            R_nc_error ("Default fill value not implemented");
         }
       }
 
@@ -407,7 +403,7 @@ R_nc_miss_att (int ncid, int varid, int mode,
             FILL2RANGE_REAL(double, DBL_EPSILON);
             break;
           default:
-            return 0;
+            R_nc_error ("Default valid range not implemented");
         }
       }
 


### PR DESCRIPTION
Valgrind reported an invalid memory access when copying the fill value for a user-defined type. This highlighted two problems and solutions:

1. NetCDF attribute conventions do not define the expected handling of missing values for user-defined types. Rather than adopting our own convention, it is safer to let users decide for themselves and handle missing values in their own R code.

2. Missing values (and related parameters) are determined in function `R_nc_miss_att`, and they are passed to other routines as void pointers. The size of the data types is assumed by the called routines, but mismatches can easily occur. As a safety precaution, the size of the missing values (and related parameters) can be passed as an extra argument. Routines can then check that the void pointers have the expected size.