### PR TITLE
Fix Windows builds on r-hub

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -6,9 +6,12 @@ PKG_CPPFLAGS = -I../windows/netcdf-${VERSION}/include \
 	-DHAVE_NC_INQ_VAR_SZIP \
 	-DHAVE_NC_INQ_VAR_ENDIAN \
 
-PKG_LIBS = -L../windows/netcdf-${VERSION}/lib${R_ARCH} \
-	-lnetcdf -lcurl -lhdf5_hl -lhdf5 -ludunits2 -lexpat -lszip -lz \
-	-lws2_32 -lcrypt32 -lwldap32
+WINLIBS = ../windows/netcdf-${VERSION}/lib${R_ARCH}
+
+PKG_LIBS = $(WINLIBS)/libnetcdf.a $(WINLIBS)/libcurl.a \
+  $(WINLIBS)/libhdf5_hl.a $(WINLIBS)/libhdf5.a $(WINLIBS)/libszip.a \
+  $(WINLIBS)/libudunits2.a $(WINLIBS)/libexpat.a \
+  -lz -lws2_32 -lcrypt32 -lwldap32
 
 all: clean winlibs
 


### PR DESCRIPTION
Windows platforms on https://builder.r-hub.io were unable to build RNetCDF, even using netcdf and hdf5 libraries from https://github.com/rwinlib . For unknown reasons, the local library path was being searched before user-defined library paths in the link step. This problem does not occur on https://win-builder.r-project.org.

As a solution to this problem, the static libraries from rwinlib can be linked explicitly by specifying their relative pathnames, without relying on the search path set by `-L`. The solution works on both r-hub and win-builder.