### PR TITLE
Fix warnings from rchk

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RNetCDF
-Version: 2.1-1
-Date: 2019-10-18
+Version: 2.2-1
+Date: 2019-11-24
 Title: Interface to 'NetCDF' Datasets
 Authors@R: c(person("Pavel", "Michna", role = "aut",
                     email = "rnetcdf-devel@bluewin.ch"),

--- a/src/attribute.c
+++ b/src/attribute.c
@@ -285,7 +285,7 @@ R_nc_put_att (SEXP nc, SEXP var, SEXP att, SEXP type, SEXP data)
       /* Find the field by name in the R input list */
       namelist = getAttrib (data, R_NamesSymbol);
       if (!isString (namelist)) {
-	R_nc_error ("Named list required for conversion to compound type");
+	error ("Named list required for conversion to compound type");
       }
       nlist = xlength (namelist);
 
@@ -298,7 +298,7 @@ R_nc_put_att (SEXP nc, SEXP var, SEXP att, SEXP type, SEXP data)
         }
       }
       if (!ismatch) {
-        R_nc_error ("Name of compound field not found in input list");
+        error ("Name of compound field not found in input list");
       }
 
       /* Find length of field in R input list */

--- a/src/attribute.c
+++ b/src/attribute.c
@@ -173,13 +173,15 @@ R_nc_get_att (SEXP nc, SEXP var, SEXP att, SEXP rawchar, SEXP fitnum)
   R_nc_check (R_nc_enddef (ncid));
 
   /*-- Allocate memory and read attribute from file ---------------------------*/
-  buf = R_nc_c2r_init (&io, NULL, ncid, xtype, -1, &cnt,
-                       israw, isfit, 0, NULL, NULL, NULL, NULL, NULL);
+  buf = NULL;
+  result = PROTECT(R_nc_c2r_init (&io, &buf, ncid, xtype, -1, &cnt,
+                   israw, isfit, 0, NULL, NULL, NULL, NULL, NULL));
   if (cnt > 0) {
     R_nc_check (nc_get_att (ncid, varid, attname, buf));
   }
-  result = R_nc_c2r (&io);
+  R_nc_c2r (&io);
 
+  UNPROTECT(1);
   return result;
 }
 

--- a/src/attribute.c
+++ b/src/attribute.c
@@ -102,7 +102,7 @@ R_nc_copy_att (SEXP nc_in, SEXP var_in, SEXP att, SEXP nc_out, SEXP var_out)
   R_nc_check (nc_copy_att (ncid_in, varid_in, attname,
                            ncid_out, varid_out));
 
-  RRETURN(R_NilValue);
+  return R_NilValue;
 }
 
 
@@ -133,7 +133,7 @@ R_nc_delete_att (SEXP nc, SEXP var, SEXP att)
   /*-- Delete the attribute ---------------------------------------------------*/
   R_nc_check (nc_del_att (ncid, varid, attname));
 
-  RRETURN(R_NilValue);
+  return R_NilValue;
 }
 
 
@@ -180,7 +180,7 @@ R_nc_get_att (SEXP nc, SEXP var, SEXP att, SEXP rawchar, SEXP fitnum)
   }
   result = R_nc_c2r (&io);
 
-  RRETURN (result);
+  return result;
 }
 
 
@@ -217,14 +217,15 @@ R_nc_inq_att (SEXP nc, SEXP var, SEXP att)
   R_nc_check (R_nc_type2str (ncid, type, atttype));
 
   /*-- Returning the list -----------------------------------------------------*/
-  result = R_nc_protect (allocVector (VECSXP, 4));
+  result = PROTECT(allocVector (VECSXP, 4));
   SET_VECTOR_ELT (result, 0, ScalarInteger (attid));
   SET_VECTOR_ELT (result, 1, mkString (attname));
   SET_VECTOR_ELT (result, 2, mkString (atttype));
   /* cnt may not fit in integer, so return as double */
   SET_VECTOR_ELT (result, 3, ScalarReal (cnt));
 
-  RRETURN(result);
+  UNPROTECT(1);
+  return result;
 }
 
 
@@ -321,7 +322,7 @@ R_nc_put_att (SEXP nc, SEXP var, SEXP att, SEXP type, SEXP data)
     R_nc_check (nc_put_att (ncid, varid, attname, xtype, cnt, buf));
   }
 
-  RRETURN (R_NilValue);
+  return R_NilValue;
 }
 
 
@@ -354,7 +355,7 @@ R_nc_rename_att (SEXP nc, SEXP var, SEXP att, SEXP newname)
   /*-- Rename the attribute ---------------------------------------------------*/
   R_nc_check (nc_rename_att (ncid, varid, attname, newattname));
 
-  RRETURN(R_NilValue);
+  return R_NilValue;
 }
 
 

--- a/src/common.c
+++ b/src/common.c
@@ -39,18 +39,12 @@
 
 #include "common.h"
 
-void
-R_nc_error(const char *msg)
-{
-  error (msg);
-}
-
 
 int
 R_nc_check(int status)
 {
   if (status != NC_NOERR) {
-    R_nc_error (nc_strerror (status));
+    error (nc_strerror (status));
   }
   return status;
 }
@@ -335,13 +329,13 @@ R_nc_sizearg (SEXP size)
         result = dval;
       }
     } else {
-      R_nc_error ("Size argument has unsupported R type");
+      error ("Size argument has unsupported R type");
     }
   } else {
-    R_nc_error ("Size argument must contain at least one numeric value");
+    error ("Size argument must contain at least one numeric value");
   }
   if (erange) {
-    R_nc_error ("Size argument is outside valid range");
+    error ("Size argument is outside valid range");
   }
   return result;
 }

--- a/src/common.c
+++ b/src/common.c
@@ -39,31 +39,9 @@
 
 #include "common.h"
 
-static int R_nc_protect_count = 0;
-
-SEXP
-R_nc_protect (SEXP obj)
-{
-  PROTECT(obj);
-  R_nc_protect_count++;
-  return obj;
-}
-
-
-void
-R_nc_unprotect (void)
-{
-  if (R_nc_protect_count > 0) {
-    UNPROTECT (R_nc_protect_count);
-    R_nc_protect_count = 0;
-  }
-}
-
-
 void
 R_nc_error(const char *msg)
 {
-  R_nc_unprotect ();
   error (msg);
 }
 

--- a/src/common.c
+++ b/src/common.c
@@ -293,7 +293,7 @@ R_nc_strarg (SEXP str)
   if (xlength (str) > 0 && isString (str)) {
     return CHAR (STRING_ELT (str, 0));
   } else {
-    RERROR ("Expected character string as argument");
+    error ("Expected character string as argument");
   }
 }
 

--- a/src/common.h
+++ b/src/common.h
@@ -40,8 +40,6 @@
   #define NC_MAX_ATOMIC_TYPE NC_STRING
 #endif
 
-#define RERROR(msg) { R_nc_error (msg); return NULL; }
-
 #define NA_SIZE SIZE_MAX
 
 /* Definition of missing value used by bit64 package */

--- a/src/common.h
+++ b/src/common.h
@@ -50,10 +50,6 @@ static const char RNC_EDATALEN[]="Not enough data", \
   RNC_EDATATYPE[]="Incompatible data for external type", \
   RNC_ETYPEDROP[]="Unsupported external type";
 
-/* Raise an error in R */
-void
-R_nc_error(const char *msg);
-
 /* If status is a netcdf error, raise an R error with a suitable message,
    otherwise return to caller. */
 int

--- a/src/common.h
+++ b/src/common.h
@@ -40,8 +40,6 @@
   #define NC_MAX_ATOMIC_TYPE NC_STRING
 #endif
 
-#define RRETURN(object) { R_nc_unprotect (); return (object); }
-
 #define RERROR(msg) { R_nc_error (msg); return NULL; }
 
 #define NA_SIZE SIZE_MAX
@@ -53,14 +51,6 @@
 static const char RNC_EDATALEN[]="Not enough data", \
   RNC_EDATATYPE[]="Incompatible data for external type", \
   RNC_ETYPEDROP[]="Unsupported external type";
-
-/* Protect an object from garbage collection by R */
-SEXP
-R_nc_protect (SEXP obj);
-
-/* Unprotect all objects to enable garbage collection by R */
-void
-R_nc_unprotect (void);
 
 /* Raise an error in R */
 void

--- a/src/convert.c
+++ b/src/convert.c
@@ -125,7 +125,7 @@ R_nc_length_sexp (SEXP count)
       length *= rcount[ii]; 
     }
     if (!R_FINITE (length)) {
-      R_nc_error ("Non-finite length in R_nc_length_sexp");
+      error ("Non-finite length in R_nc_length_sexp");
     }
   } else if (isInteger (count)) {
     icount = INTEGER (count);
@@ -133,11 +133,11 @@ R_nc_length_sexp (SEXP count)
       if (icount[ii] != NA_INTEGER) {
         length *= icount[ii];
       } else {
-        R_nc_error ("Missing value in R_nc_length_sexp");
+        error ("Missing value in R_nc_length_sexp");
       }
     }
   } else if (!isNull (count)) {
-    R_nc_error ("Unsupported type in R_nc_length_sexp");
+    error ("Unsupported type in R_nc_length_sexp");
   }
 
   return (length);
@@ -394,7 +394,7 @@ FUN (SEXP rv, int ndim, const size_t *xdim, \
   } \
   if (fill) { \
     if (fillsize != sizeof(OTYPE)) { \
-      R_nc_error ("Size of fill value does not match output type"); \
+      error ("Size of fill value does not match output type"); \
     } \
     fillval = *fill; \
   } \
@@ -417,9 +417,9 @@ FUN (SEXP rv, int ndim, const size_t *xdim, \
     } \
   } \
   if ( erange ) { \
-    R_nc_error (nc_strerror (NC_ERANGE)); \
+    error (nc_strerror (NC_ERANGE)); \
   } else if ( efill ) { \
-    R_nc_error ("NA values sent to netcdf without conversion to fill value"); \
+    error ("NA values sent to netcdf without conversion to fill value"); \
   } \
   return out; \
 }
@@ -550,7 +550,7 @@ FUN (R_nc_buf *io) \
   in = (ITYPE *) io->cbuf; \
   out = (OTYPE *) io->rbuf; \
   if ((io->fill || io->min || io->max ) && io->fillsize != sizeof(ITYPE)) { \
-    R_nc_error ("Size of fill value does not match input type"); \
+    error ("Size of fill value does not match input type"); \
   } \
   if (io->fill) { \
     fillval = *((ITYPE *) io->fill); \
@@ -656,7 +656,7 @@ FUN (R_nc_buf *io) \
     offset = 0.0; \
   } \
   if ((io->fill || io->min || io->max) && io->fillsize != sizeof(ITYPE)) { \
-    R_nc_error ("Size of fill value does not match input type"); \
+    error ("Size of fill value does not match input type"); \
   } \
   if (io->fill) { \
     fillval = *((ITYPE *) io->fill); \
@@ -1042,7 +1042,7 @@ R_nc_enum_factor (R_nc_buf *io)
     index = findVarInFrame3 (env, symbol, TRUE);
     UNPROTECT(1);
     if (index == R_UnboundValue) {
-      R_nc_error ("Unknown enum value in variable");
+      error ("Unknown enum value in variable");
     } else {
       out[ifac] = INTEGER (index)[0];
     }
@@ -1076,11 +1076,11 @@ R_nc_vecsxp_compound (SEXP rv, int ncid, nc_type xtype, int ndim, const size_t *
   /* Check names attribute of R list */
   namelist = PROTECT(getAttrib (rv, R_NamesSymbol));
   if (!isString (namelist)) {
-    R_nc_error ("Named list required for conversion to compound type");
+    error ("Named list required for conversion to compound type");
   }
   nlist = xlength (namelist);
   if (nlist < nfld) {
-    R_nc_error ("Not enough fields in list for conversion to compound type");
+    error ("Not enough fields in list for conversion to compound type");
   }
 
   /* Allocate memory for compound array,
@@ -1116,7 +1116,7 @@ R_nc_vecsxp_compound (SEXP rv, int ncid, nc_type xtype, int ndim, const size_t *
       }
     }
     if (!ismatch) {
-      R_nc_error ("Name of compound field not found in input list");
+      error ("Name of compound field not found in input list");
     }
 
     /* Convert the field from R to C.
@@ -1161,7 +1161,7 @@ R_nc_compound_vecsxp_init (R_nc_buf *io)
    */
   if (R_nc_redef (io->ncid) == NC_NOERR) {
     /* Dataset must be writable because it is now in define mode */
-    R_nc_error ("Please read compound type from a read-only dataset");
+    error ("Please read compound type from a read-only dataset");
   }
 
   /* Get number of fields in compound type */

--- a/src/convert.c
+++ b/src/convert.c
@@ -195,7 +195,7 @@ R_nc_strsxp_char (SEXP rstr, int ndim, const size_t *xdim)
     cnt = 1;
   }
   if (xlength (rstr) < cnt) {
-    RERROR (RNC_EDATALEN);
+    error (RNC_EDATALEN);
   }
   carr = R_alloc (cnt*strlen, sizeof (char));
   for (ii=0, thisstr=carr; ii<cnt; ii++, thisstr+=strlen) {
@@ -257,7 +257,7 @@ R_nc_raw_char (SEXP rarr, int ndim, const size_t *xdim)
   size_t cnt;
   cnt = R_nc_length (ndim, xdim);
   if (xlength (rarr) < cnt) {
-    RERROR (RNC_EDATALEN);
+    error (RNC_EDATALEN);
   }
   return (const char *) RAW (rarr);
 }
@@ -293,7 +293,7 @@ R_nc_strsxp_str (SEXP rstr, int ndim, const size_t *xdim)
   const char **cstr;
   cnt = R_nc_length (ndim, xdim);
   if (xlength (rstr) < cnt) {
-    RERROR (RNC_EDATALEN);
+    error (RNC_EDATALEN);
   }
   cstr = (const char **) R_alloc (cnt, sizeof(size_t));
   for (ii=0; ii<cnt; ii++) {
@@ -375,7 +375,7 @@ FUN (SEXP rv, int ndim, const size_t *xdim, \
   in = (ITYPE *) IFUN (rv); \
   cnt = R_nc_length (ndim, xdim); \
   if (xlength (rv) < cnt) { \
-    RERROR (RNC_EDATALEN); \
+    error (RNC_EDATALEN); \
   } \
   if (fill || scale || add || (NCITYPE != NCOTYPE)) { \
     out = (OTYPE *) R_alloc (cnt, sizeof(OTYPE)); \
@@ -725,7 +725,7 @@ R_nc_vecsxp_vlen (SEXP rv, int ncid, nc_type xtype, int ndim, const size_t *xdim
 
   cnt = R_nc_length (ndim, xdim);
   if (xlength (rv) < cnt) {
-    RERROR (RNC_EDATALEN);
+    error (RNC_EDATALEN);
   }
 
   R_nc_check (nc_inq_user_type (ncid, xtype, NULL, NULL, &basetype, NULL, NULL));
@@ -826,7 +826,7 @@ R_nc_raw_opaque (SEXP rv, int ncid, nc_type xtype, int ndim, const size_t *xdim)
   R_nc_check (nc_inq_user_type (ncid, xtype, NULL, &size, NULL, NULL, NULL));
   cnt = R_nc_length (ndim, xdim);
   if (xlength (rv) < (cnt * size)) {
-    RERROR (RNC_EDATALEN);
+    error (RNC_EDATALEN);
   }
   return (const char *) RAW (rv);
 }
@@ -895,7 +895,7 @@ R_nc_factor_enum (SEXP rv, int ncid, nc_type xtype, int ndim, const size_t *xdim
 
   levels = getAttrib (rv, R_LevelsSymbol);
   if (!isString (levels)) {
-    RERROR ("Expected character vector for levels of factor array")
+    error ("Expected character vector for levels of factor array");
   }
 
   nlev = xlength (levels);
@@ -931,7 +931,7 @@ R_nc_factor_enum (SEXP rv, int ncid, nc_type xtype, int ndim, const size_t *xdim
       }
     }
     if (!ismatch) {
-      RERROR ("Level has no matching member in enum type")
+      error ("Level has no matching member in enum type");
     }
   }
 
@@ -945,7 +945,7 @@ R_nc_factor_enum (SEXP rv, int ncid, nc_type xtype, int ndim, const size_t *xdim
       imem = ilev2mem[inval-1];
       memcpy(out + ifac*size, memvals + imem*size, size);
     } else {
-      RERROR ("Invalid index in factor")
+      error ("Invalid index in factor");
     }
   }
 
@@ -1391,7 +1391,7 @@ R_nc_r2c (SEXP rv, int ncid, nc_type xtype, int ndim, const size_t *xdim,
     }
     break;
   }
-  RERROR (RNC_EDATATYPE);
+  error (RNC_EDATATYPE);
 }
 
 SEXP \
@@ -1404,7 +1404,7 @@ R_nc_c2r_init (R_nc_buf *io, void **cbuf,
   int class;
 
   if (!io) {
-    RERROR ("Pointer to R_nc_buf must not be NULL in R_nc_c2r_init");
+    error ("Pointer to R_nc_buf must not be NULL in R_nc_c2r_init");
   }
 
   /* Initialise the R_nc_buf, making copies of pointer arguments */
@@ -1515,10 +1515,10 @@ R_nc_c2r_init (R_nc_buf *io, void **cbuf,
           PROTECT(R_nc_opaque_raw_init (io));
           break;
         default:
-          RERROR (RNC_ETYPEDROP);
+          error (RNC_ETYPEDROP);
         }
       } else {
-        RERROR (RNC_ETYPEDROP);
+        error (RNC_ETYPEDROP);
       }
   }
 
@@ -1715,7 +1715,7 @@ FUN (SEXP rv, size_t N, TYPE fillval) \
   } else if (isInteger (rv)) { \
     voidbuf = R_nc_r2c_int_##TYPENAME (rv, 1, &nr, sizeof(TYPE), &fillval, NULL, NULL); \
   } else { \
-    RERROR ("Unsupported R type in R_NC_DIM_R2C"); \
+    error ("Unsupported R type in R_NC_DIM_R2C"); \
   } \
   memcpy (cv, voidbuf, nr*sizeof (TYPE)); \
 \

--- a/src/convert.h
+++ b/src/convert.h
@@ -85,9 +85,10 @@ R_nc_r2c (SEXP rv, int ncid, nc_type xtype, int ndim, const size_t *xdim,
 /* Convert an array of netcdf external type (xtype) to R.
    Memory buffers for R and (optionally) C arrays are allocated by R_nc_c2r_init;
    the C to R conversion is performed by R_nc_c2r, and memory is freed by R.
+   The SEXP result of R_nc_c2r_init should be PROTECTed by the caller.
    Argument io is a pointer to an existing R_nc_buf (must not be NULL).
-   The result of R_nc_c2r_init is a pointer to the C buffer used for netcdf functions,
-   which may be specified by argument cbuf or internally allocated if cbuf is NULL.
+   Argument cbuf is a pointer to a pointer to a buffer for netcdf data,
+   which will be allocated internally if *cbuf is NULL.
    The number and lengths of netcdf dimensions are ndim and xdim (C-order).
    The special case ndims < 0 gives a vector (no dim attribute) of length xdim[0].
    If fitnum is true (non-zero), rv is the smallest compatible R numeric type,
@@ -97,14 +98,14 @@ R_nc_r2c (SEXP rv, int ncid, nc_type xtype, int ndim, const size_t *xdim,
    Elements are set to missing if they equal the fill value.
    Unpacking is performed if either scale or add are not NULL.
  */
-void * \
-R_nc_c2r_init (R_nc_buf *io, void *cbuf,
+SEXP \
+R_nc_c2r_init (R_nc_buf *io, void **cbuf,
                int ncid, nc_type xtype, int ndim, const size_t *xdim,
                int rawchar, int fitnum, size_t fillsize,
                const void *fill, const void *min, const void *max,
                const double *scale, const double *add);
 
-SEXP
+void \
 R_nc_c2r (R_nc_buf *io);
 
 

--- a/src/dataset.c
+++ b/src/dataset.c
@@ -90,14 +90,14 @@ R_nc_close (SEXP ptr)
 
   fileid = R_ExternalPtrAddr (ptr);
   if (!fileid) {
-    RRETURN(R_NilValue);
+    return R_NilValue;
   }
 
   R_nc_check (nc_close (*fileid));
   R_Free (fileid);
   R_ClearExternalPtr (ptr);
 
-  RRETURN(R_NilValue);
+  return R_NilValue;
 }
 
 /* Private function used as finalizer during garbage collection.
@@ -156,19 +156,20 @@ R_nc_create (SEXP filename, SEXP clobber, SEXP share, SEXP prefill,
   } else {
     RERROR ("Filename must be a non-empty string");
   }
-  result = R_nc_protect (ScalarInteger (ncid));
+  result = PROTECT(ScalarInteger (ncid));
 
   /*-- Arrange for file to be closed if handle is garbage collected -----------*/
   fileid = R_Calloc (1, int);
   *fileid = ncid;
-  Rptr = R_nc_protect (R_MakeExternalPtr (fileid, R_NilValue, R_NilValue));
+  Rptr = PROTECT(R_MakeExternalPtr (fileid, R_NilValue, R_NilValue));
   R_RegisterCFinalizerEx (Rptr, &R_nc_finalizer, TRUE);
   setAttrib (result, install ("handle_ptr"), Rptr);
 
   /*-- Set the fill mode ------------------------------------------------------*/
   R_nc_check (nc_set_fill (ncid, fillmode, &old_fillmode));
 
-  RRETURN(result);
+  UNPROTECT(2);
+  return result;
 }
 
 
@@ -197,7 +198,7 @@ R_nc_inq_file (SEXP nc)
   libvers = nc_inq_libvers ();
 
   /*-- Returning the list -----------------------------------------------------*/
-  result = R_nc_protect (allocVector (VECSXP, 6)); 
+  result = PROTECT(allocVector (VECSXP, 6)); 
   SET_VECTOR_ELT (result, 0, ScalarInteger (ndims));
   SET_VECTOR_ELT (result, 1, ScalarInteger (nvars));
   SET_VECTOR_ELT (result, 2, ScalarInteger (ngatts));
@@ -205,7 +206,8 @@ R_nc_inq_file (SEXP nc)
   SET_VECTOR_ELT (result, 4, mkString (R_nc_format2str (format)));
   SET_VECTOR_ELT (result, 5, mkString (libvers));
 
-  RRETURN(result);
+  UNPROTECT(1);
+  return result;
 }
 
 
@@ -245,12 +247,12 @@ R_nc_open (SEXP filename, SEXP write, SEXP share, SEXP prefill)
   } else {
     RERROR ("Filename must be a non-empty string");
   }
-  result = R_nc_protect (ScalarInteger (ncid));
+  result = PROTECT(ScalarInteger (ncid));
 
   /*-- Arrange for file to be closed if handle is garbage collected -----------*/
   fileid = R_Calloc (1, int);
   *fileid = ncid;
-  Rptr = R_nc_protect (R_MakeExternalPtr (fileid, R_NilValue, R_NilValue));
+  Rptr = PROTECT(R_MakeExternalPtr (fileid, R_NilValue, R_NilValue));
   R_RegisterCFinalizerEx (Rptr, &R_nc_finalizer, TRUE);
   setAttrib (result, install ("handle_ptr"), Rptr);
 
@@ -259,7 +261,8 @@ R_nc_open (SEXP filename, SEXP write, SEXP share, SEXP prefill)
     R_nc_check (nc_set_fill (ncid, fillmode, &old_fillmode));
   }
 
-  RRETURN(result);
+  UNPROTECT(2);
+  return result;
 }
 
 
@@ -279,6 +282,6 @@ R_nc_sync (SEXP nc)
   /*-- Sync the file ----------------------------------------------------------*/
   R_nc_check (nc_sync (ncid));
 
-  RRETURN(R_NilValue);
+  return R_NilValue;
 }
 

--- a/src/dataset.c
+++ b/src/dataset.c
@@ -85,7 +85,7 @@ R_nc_close (SEXP ptr)
   int *fileid;
 
   if (TYPEOF (ptr) != EXTPTRSXP) {
-    RERROR ("Not a valid NetCDF object");
+    error ("Not a valid NetCDF object");
   }
 
   fileid = R_ExternalPtrAddr (ptr);
@@ -154,7 +154,7 @@ R_nc_create (SEXP filename, SEXP clobber, SEXP share, SEXP prefill,
   if (strlen (filep) > 0) {
     R_nc_check (nc_create (R_ExpandFileName (filep), cmode, &ncid));
   } else {
-    RERROR ("Filename must be a non-empty string");
+    error ("Filename must be a non-empty string");
   }
   result = PROTECT(ScalarInteger (ncid));
 
@@ -245,7 +245,7 @@ R_nc_open (SEXP filename, SEXP write, SEXP share, SEXP prefill)
   if (strlen (filep) > 0) {
     R_nc_check (nc_open (R_ExpandFileName (filep), omode, &ncid));
   } else {
-    RERROR ("Filename must be a non-empty string");
+    error ("Filename must be a non-empty string");
   }
   result = PROTECT(ScalarInteger (ncid));
 

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -76,8 +76,7 @@ R_nc_def_dim (SEXP nc, SEXP dimname, SEXP size, SEXP unlim)
 
   R_nc_check (nc_def_dim (ncid, dimnamep, nccnt, &dimid));
 
-  result = R_nc_protect (ScalarInteger (dimid));
-  RRETURN(result);
+  return ScalarInteger (dimid);
 }
 
 
@@ -134,7 +133,7 @@ R_nc_inq_unlimids (SEXP nc)
 
   R_nc_check (R_nc_unlimdims (ncid, &nunlim, &unlimids));
 
-  result = R_nc_protect (allocVector (INTSXP, nunlim));
+  result = PROTECT(allocVector (INTSXP, nunlim));
 
   /* Sort temporary results and copy to output structure */
   if (nunlim > 0) {
@@ -142,7 +141,8 @@ R_nc_inq_unlimids (SEXP nc)
     memcpy (INTEGER (result), unlimids, nunlim * sizeof (int));
   }
 
-  RRETURN(result);
+  UNPROTECT(1);
+  return result;
 }
 
 
@@ -178,14 +178,14 @@ R_nc_inq_dim (SEXP nc, SEXP dim)
   }
 
   /*-- Returning the list -----------------------------------------------------*/
-  result = R_nc_protect (allocVector (VECSXP, 4));
+  result = PROTECT(allocVector (VECSXP, 4));
   SET_VECTOR_ELT (result, 0, ScalarInteger (dimid));
   SET_VECTOR_ELT (result, 1, mkString (dimname));
   /* Dimension length may be larger than integer, so return as double */
   SET_VECTOR_ELT (result, 2, ScalarReal (dimlen));
   SET_VECTOR_ELT (result, 3, ScalarLogical (isunlim));
 
-  RRETURN(result);
+  return result;
 }
 
 
@@ -212,7 +212,7 @@ R_nc_rename_dim (SEXP nc, SEXP dim, SEXP newname)
   /*-- Rename the dimension ---------------------------------------------------*/
   R_nc_check (nc_rename_dim (ncid, dimid, newnamep));
 
-  RRETURN(R_NilValue);
+  return R_NilValue;
 }
 
 

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -184,6 +184,7 @@ R_nc_inq_dim (SEXP nc, SEXP dim)
   SET_VECTOR_ELT (result, 2, ScalarReal (dimlen));
   SET_VECTOR_ELT (result, 3, ScalarLogical (isunlim));
 
+  UNPROTECT(1);
   return result;
 }
 

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -57,7 +57,6 @@ R_nc_def_dim (SEXP nc, SEXP dimname, SEXP size, SEXP unlim)
   int ncid, dimid;
   const char *dimnamep;
   size_t nccnt;
-  SEXP result;
 
   /*-- Convert arguments to netcdf ids ----------------------------------------*/
   ncid = asInteger (nc);

--- a/src/group.c
+++ b/src/group.c
@@ -56,7 +56,6 @@ R_nc_def_grp (SEXP nc, SEXP grpname)
 {
   int ncid, grpid;
   const char *cgrpname;
-  SEXP result;
 
   /* Convert arguments to netcdf ids */
   ncid = asInteger (nc);
@@ -69,8 +68,7 @@ R_nc_def_grp (SEXP nc, SEXP grpname)
   /* Define the group */
   R_nc_check (nc_def_grp (ncid, cgrpname, &grpid));
 
-  result = R_nc_protect (ScalarInteger (grpid));
-  RRETURN(result);
+  return ScalarInteger (grpid);
 }
 
 
@@ -81,14 +79,12 @@ SEXP
 R_nc_inq_grp_parent (SEXP nc)
 {
   int ncid, grpid;
-  SEXP result;
 
   /* Get parent group */
   ncid = asInteger (nc);
   R_nc_check (nc_inq_grp_parent (ncid, &grpid));
 
-  result = R_nc_protect (ScalarInteger (grpid));
-  RRETURN(result);
+  return ScalarInteger (grpid);
 }
 
 
@@ -99,14 +95,12 @@ SEXP
 R_nc_inq_natts (SEXP nc)
 {
   int ncid, natts;
-  SEXP result;
 
   /* Get number of attributes in group */
   ncid = asInteger (nc);
   R_nc_check (nc_inq_natts (ncid, &natts));
 
-  result = R_nc_protect (ScalarInteger (natts));
-  RRETURN(result);
+  return ScalarInteger (natts);
 }
 
 
@@ -134,8 +128,7 @@ R_nc_inq_grpname (SEXP nc, SEXP full)
     name = namebuf;
   }
 
-  result = R_nc_protect (mkString (name));
-  RRETURN(result);
+  return mkString (name);
 }
 
 
@@ -158,8 +151,7 @@ R_nc_inq_grp_ncid (SEXP nc, SEXP grpname, SEXP full)
     R_nc_check (nc_inq_grp_ncid (ncid, cgrpname, &grpid));
   }
 
-  result = R_nc_protect (ScalarInteger (grpid));
-  RRETURN(result);
+  return ScalarInteger (grpid);
 }
 
 
@@ -175,9 +167,10 @@ SEXP RFUN (SEXP nc) \
   SEXP result; \
   ncid = asInteger (nc); \
   R_nc_check(NCFUN(ncid, &count, NULL)); \
-  result = R_nc_protect (allocVector (INTSXP, count)); \
+  result = PROTECT(allocVector (INTSXP, count)); \
   R_nc_check(NCFUN(ncid, NULL, INTEGER(result))); \
-  RRETURN(result); \
+  UNPROTECT(1); \
+  return result; \
 }
 
 INQGRPIDS (R_nc_inq_grps, nc_inq_grps)
@@ -199,10 +192,10 @@ R_nc_inq_dimids (SEXP nc, SEXP ancestors)
   full = (asLogical (ancestors) == TRUE);
 
   R_nc_check (nc_inq_dimids (ncid, &count, NULL, full));
-  result = R_nc_protect (allocVector (INTSXP, count));
+  result = PROTECT(allocVector (INTSXP, count));
   R_nc_check (nc_inq_dimids (ncid, NULL, INTEGER (result), full));
-
-  RRETURN(result);
+  UNPROTECT(1);
+  return result;
 }
 
 
@@ -225,7 +218,7 @@ R_nc_rename_grp (SEXP nc, SEXP grpname)
   /* Rename the group */
   R_nc_check (nc_rename_grp (ncid, cgrpname));
 
-  RRETURN(R_NilValue);
+  return R_NilValue;
 
 #else
   RERROR ("nc_rename_grp not supported by netcdf library");

--- a/src/group.c
+++ b/src/group.c
@@ -219,7 +219,7 @@ R_nc_rename_grp (SEXP nc, SEXP grpname)
   return R_NilValue;
 
 #else
-  RERROR ("nc_rename_grp not supported by netcdf library");
+  error ("nc_rename_grp not supported by netcdf library");
 #endif
 }
 

--- a/src/group.c
+++ b/src/group.c
@@ -113,7 +113,6 @@ R_nc_inq_grpname (SEXP nc, SEXP full)
   int ncid;
   size_t namelen;
   char *name, *fullname, namebuf[NC_MAX_NAME+1];
-  SEXP result;
 
   ncid = asInteger (nc);
 
@@ -140,7 +139,6 @@ R_nc_inq_grp_ncid (SEXP nc, SEXP grpname, SEXP full)
 {
   int ncid, grpid;
   const char *cgrpname;
-  SEXP result;
 
   ncid = asInteger (nc);
   cgrpname = R_nc_strarg (grpname);

--- a/src/type.c
+++ b/src/type.c
@@ -67,9 +67,9 @@ R_nc_def_compound (int ncid, const char *typename,
   /*-- Check arguments -------------------------------------------------------*/
   nfld = xlength (names);
   if (xlength (subtypes) != nfld || xlength (dimsizes) != nfld) {
-    R_nc_error ("Lengths of names, subtypes and dimsizes must match");
+    error ("Lengths of names, subtypes and dimsizes must match");
   } else if (nfld < 1) {
-    R_nc_error ("Compound type must have at least one field");
+    error ("Compound type must have at least one field");
   }
 
   /*-- Calculate field offsets with suitable alignment for each native subtype,
@@ -111,7 +111,7 @@ R_nc_def_compound (int ncid, const char *typename,
     R_nc_check (nc_inq_user_type (ncid, typeid, NULL, &xsize,
                                   NULL, NULL, &class));
     if (class != NC_COMPOUND || xsize != typesize) {
-      R_nc_error ("Existing type has same name but different class or size");
+      error ("Existing type has same name but different class or size");
     }
     warning("Inserting fields in existing type %s", typename);
   } else {
@@ -132,7 +132,7 @@ R_nc_def_compound (int ncid, const char *typename,
 	csizes = R_nc_dim_r2c_int(shape, ndims, 0);
       }
     } else {
-      R_nc_error ("Dimensions of field must be numeric or null");
+      error ("Dimensions of field must be numeric or null");
       return NC_NAT;
     }
 
@@ -166,7 +166,7 @@ R_nc_def_enum (int ncid, const char *typename, SEXP basetype,
   R_nc_check (R_nc_type_id (basetype, ncid, &xtype, 0));
   nval = xlength (values);
   if (xlength (names) != nval) {
-    R_nc_error ("Lengths of names and values must match");
+    error ("Lengths of names and values must match");
   }
 
   cvals = R_nc_r2c (values, ncid, xtype, 1, &nval, 0, NULL, NULL, NULL);
@@ -181,7 +181,7 @@ R_nc_def_enum (int ncid, const char *typename, SEXP basetype,
     R_nc_check (nc_inq_user_type (ncid, typeid, NULL, NULL,
                                   &xtype2, NULL, &class));
     if (class != NC_ENUM || xtype != xtype2) {
-      R_nc_error ("Existing type has same name but different class or basetype");
+      error ("Existing type has same name but different class or basetype");
     }
     warning("Inserting members in existing type %s", typename);
   } else {
@@ -473,7 +473,7 @@ R_nc_inq_type (SEXP nc, SEXP type, SEXP fields)
 
       break;
     default:
-      R_nc_error ("Unknown class of user defined type");
+      error ("Unknown class of user defined type");
     }
 
   } else {

--- a/src/type.c
+++ b/src/type.c
@@ -216,7 +216,6 @@ R_nc_def_type (SEXP nc, SEXP typename, SEXP class, SEXP size, SEXP basetype,
   const char *typenamep;
   nc_type typeid=0, xtype=0;
   size_t xsize=0;
-  SEXP result;
 
   /*-- Decode arguments -------------------------------------------------------*/
   ncid = asInteger (nc);

--- a/src/type.c
+++ b/src/type.c
@@ -424,18 +424,20 @@ R_nc_inq_type (SEXP nc, SEXP type, SEXP fields)
 
 	/* Read named vector of member values */
 	fieldnames = PROTECT(allocVector (STRSXP, nfields));
-        cval = R_nc_c2r_init (&io, NULL, ncid, basetype, -1, &nfields,
-                              0, 1, 0, NULL, NULL, NULL, NULL, NULL);
+        cval = NULL;
+        values = PROTECT(R_nc_c2r_init (&io, (void **) &cval, ncid, basetype,
+                           -1, &nfields, 0, 1,
+                           0, NULL, NULL, NULL, NULL, NULL));
 
 	imax = nfields; // netcdf member index is int
 	for (ii=0; ii < imax; ii++, cval+=size) {
 	  R_nc_check (nc_inq_enum_member (ncid, xtype, ii, fieldname, cval));
 	  SET_STRING_ELT (fieldnames, ii, mkChar (fieldname));
 	}
-	values = R_nc_c2r (&io);
+	R_nc_c2r (&io);
 	SET_VECTOR_ELT (result, 5, values);
 	setAttrib (values, R_NamesSymbol, fieldnames);
-        UNPROTECT(1);
+        UNPROTECT(2);
 
       } else {
 	result = PROTECT(allocVector (VECSXP, 5));

--- a/src/type.c
+++ b/src/type.c
@@ -237,7 +237,7 @@ R_nc_def_type (SEXP nc, SEXP typename, SEXP class, SEXP size, SEXP basetype,
     R_nc_check (R_nc_type_id (basetype, ncid, &xtype, 0));
     R_nc_check (nc_def_vlen (ncid, typenamep, xtype, &typeid));
   } else {
-    RERROR ("Unknown class for type definition");
+    error ("Unknown class for type definition");
   }
 
   return ScalarInteger (typeid);
@@ -272,7 +272,7 @@ R_nc_insert_type (SEXP nc, SEXP type, SEXP name, SEXP value,
     if (!isNull (value)) {
       tmpval = R_nc_r2c (value, ncid, xtype, 0, NULL, 0, NULL, NULL, NULL);
     } else {
-      RERROR ("No value given for enumerated type");
+      error ("No value given for enumerated type");
     }
   } else if (class == NC_COMPOUND) {
     if (!isNull (offset) && !isNull (subtype)) {
@@ -296,14 +296,14 @@ R_nc_insert_type (SEXP nc, SEXP type, SEXP name, SEXP value,
       }
 
       if ( (coffset + subsize*nelem) > xsize) {
-        RERROR("Field exceeds size of compound type")
+        error("Field exceeds size of compound type");
       }
 // Keep size checks; allow repeat definition with same details.
     } else {
-      RERROR ("Missing offset or subtype for compound type");
+      error ("Missing offset or subtype for compound type");
     }
   } else {
-    RERROR ("Expected enumerated or compound type");
+    error ("Expected enumerated or compound type");
   }
 
   /*-- Enter define mode ------------------------------------------------------*/

--- a/src/type.c
+++ b/src/type.c
@@ -362,7 +362,6 @@ R_nc_inq_type (SEXP nc, SEXP type, SEXP fields)
     case NC_COMPOUND:
       if (extend) {
         result = PROTECT(allocVector (VECSXP, 7));
-        SET_VECTOR_ELT (result, 2, mkString ("compound"));
 
         resultnames = PROTECT(allocVector (STRSXP, 7));
         setAttrib (result, R_NamesSymbol, resultnames);
@@ -410,19 +409,17 @@ R_nc_inq_type (SEXP nc, SEXP type, SEXP fields)
         UNPROTECT(1);
       }
 
+      SET_VECTOR_ELT (result, 2, mkString ("compound"));
       break;
     case NC_ENUM:
       R_nc_check (R_nc_type2str (ncid, basetype, basename));
 
       if (extend) {
 	result = PROTECT(allocVector (VECSXP, 6));
-        SET_VECTOR_ELT (result, 2, mkString ("enum"));
-        SET_VECTOR_ELT (result, 4, mkString (basename));
 
 	resultnames = PROTECT(allocVector (STRSXP, 6));
         setAttrib (result, R_NamesSymbol, resultnames);
         UNPROTECT(1);
-        SET_STRING_ELT (resultnames, 4, mkChar ("basetype"));
 	SET_STRING_ELT (resultnames, 5, mkChar ("value"));
 
 	/* Read named vector of member values */
@@ -447,6 +444,9 @@ R_nc_inq_type (SEXP nc, SEXP type, SEXP fields)
         UNPROTECT(1);
       }
 
+      SET_VECTOR_ELT (result, 2, mkString ("enum"));
+      SET_VECTOR_ELT (result, 4, mkString (basename));
+      SET_STRING_ELT (resultnames, 4, mkChar ("basetype"));
       break;
     case NC_OPAQUE:
 

--- a/src/udunits.c
+++ b/src/udunits.c
@@ -67,7 +67,7 @@ R_nc_calendar (SEXP unitstring, SEXP values)
 SEXP
 R_nc_utinit (SEXP path)
 {
-  RRETURN(R_NilValue);
+  return R_NilValue;
 }
 
 SEXP
@@ -79,7 +79,7 @@ R_nc_inv_calendar (SEXP unitstring, SEXP values)
 SEXP
 R_nc_utterm ()
 {
-  RRETURN(R_NilValue);
+  return R_NilValue;
 }
 
 #else
@@ -170,7 +170,7 @@ R_nc_calendar (SEXP unitstring, SEXP values)
   }
   count = xlength (values);
 
-  result = R_nc_protect (allocMatrix (REALSXP, count, 6));
+  result = PROTECT(allocMatrix (REALSXP, count, 6));
   dout = REAL (result);
 
   /* Parse unitstring */
@@ -239,7 +239,8 @@ cleanup:
     RERROR (R_nc_uterror (status));
   }
 
-  RRETURN(result);
+  UNPROTECT(1);
+  return result;
 }
 
 
@@ -262,7 +263,7 @@ R_nc_utinit (SEXP path)
   if (!R_nc_units) {
     RERROR (R_nc_uterror (ut_get_status ()));
   }
-  RRETURN(R_NilValue);
+  return R_NilValue;
 }
 
 
@@ -295,7 +296,7 @@ R_nc_inv_calendar (SEXP unitstring, SEXP values)
   }
   count = xlength (values) / 6;
 
-  result = R_nc_protect (allocVector (REALSXP, count));
+  result = PROTECT(allocVector (REALSXP, count));
   dout = REAL (result);
 
   /* Parse unitstring */
@@ -371,7 +372,8 @@ cleanup:
     RERROR (R_nc_uterror (status));
   }
 
-  RRETURN(result);
+  UNPROTECT(1);
+  return result;
 }
 
 
@@ -386,7 +388,7 @@ R_nc_utterm ()
     ut_free_system (R_nc_units);
     R_nc_units = NULL;
   }
-  RRETURN(R_NilValue);
+  return R_NilValue;
 }
 
 #endif /* Conditional compilation with UDUNITS2 */

--- a/src/udunits.c
+++ b/src/udunits.c
@@ -61,7 +61,7 @@
 SEXP
 R_nc_calendar (SEXP unitstring, SEXP values)
 {
-  RERROR ("RNetCDF was built without UDUNITS-2");
+  error ("RNetCDF was built without UDUNITS-2");
 }
 
 SEXP
@@ -73,7 +73,7 @@ R_nc_utinit (SEXP path)
 SEXP
 R_nc_inv_calendar (SEXP unitstring, SEXP values)
 {
-  RERROR ("RNetCDF was built without UDUNITS-2");
+  error ("RNetCDF was built without UDUNITS-2");
 }
 
 SEXP
@@ -236,7 +236,7 @@ cleanup:
   }
 
   if (status != UT_SUCCESS) {
-    RERROR (R_nc_uterror (status));
+    error (R_nc_uterror (status));
   }
 
   UNPROTECT(1);
@@ -261,7 +261,7 @@ R_nc_utinit (SEXP path)
   R_nc_units = ut_read_xml (pathp);
 
   if (!R_nc_units) {
-    RERROR (R_nc_uterror (ut_get_status ()));
+    error (R_nc_uterror (ut_get_status ()));
   }
   return R_NilValue;
 }
@@ -369,7 +369,7 @@ cleanup:
   }
 
   if (status != UT_SUCCESS) {
-    RERROR (R_nc_uterror (status));
+    error (R_nc_uterror (status));
   }
 
   UNPROTECT(1);

--- a/src/variable.c
+++ b/src/variable.c
@@ -639,9 +639,7 @@ R_nc_inq_var (SEXP nc, SEXP var)
 
   } else {
     /* Return single NA for scalar dimensions */
-    rdimids = PROTECT(ScalarInteger (NA_INTEGER));
-    SET_VECTOR_ELT (result, 4, rdimids);
-    UNPROTECT(1);
+    SET_VECTOR_ELT (result, 4, ScalarInteger (NA_INTEGER));
 
     if (withnc4) {
       /* Chunks not defined for scalars */
@@ -693,8 +691,7 @@ R_nc_inq_var (SEXP nc, SEXP var)
       SET_VECTOR_ELT (result, 15, ScalarInteger (NA_INTEGER));
 #  endif
     } else {
-      R_nc_check (status);
-      return R_NilValue;
+      R_nc_error (nc_strerror (status));
     }
 #else
     SET_VECTOR_ELT (result, 14, R_NilValue);
@@ -717,12 +714,9 @@ R_nc_inq_var (SEXP nc, SEXP var)
       }
     } else if (status == NC_EFILTER) {
       SET_VECTOR_ELT (result, 16, ScalarInteger (NA_INTEGER));
-      rfilter_params = PROTECT(ScalarInteger (NA_INTEGER));
-      SET_VECTOR_ELT (result, 17, rfilter_params);
-      UNPROTECT(1);
+      SET_VECTOR_ELT (result, 17, ScalarInteger (NA_INTEGER));
     } else {
-      R_nc_check (status);
-      return R_NilValue;
+      R_nc_error (nc_strerror (status));
     }
 #else
     SET_VECTOR_ELT (result, 16, R_NilValue);

--- a/src/variable.c
+++ b/src/variable.c
@@ -63,7 +63,6 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
   size_t *chunksize_t;
   nc_type xtype;
   const char *varnamep;
-  SEXP result;
 
 #ifdef HAVE_NC_INQ_VAR_ENDIAN
   int endian_mode;

--- a/src/variable.c
+++ b/src/variable.c
@@ -374,7 +374,7 @@ R_nc_miss_att (int ncid, int varid, int mode,
             **(unsigned long long **) fill = NC_FILL_UINT64;
             break;
           default:
-            R_nc_error ("Default fill value not implemented");
+            error ("Default fill value not implemented");
         }
       }
 
@@ -408,13 +408,13 @@ R_nc_miss_att (int ncid, int varid, int mode,
             FILL2RANGE_REAL(double, DBL_EPSILON);
             break;
           default:
-            R_nc_error ("Default valid range not implemented");
+            error ("Default valid range not implemented");
         }
       }
 
     }
   } else {
-    R_nc_error ("Unknown mode for handling missing values");
+    error ("Unknown mode for handling missing values");
 
   }
   return size;
@@ -691,7 +691,7 @@ R_nc_inq_var (SEXP nc, SEXP var)
       SET_VECTOR_ELT (result, 15, ScalarInteger (NA_INTEGER));
 #  endif
     } else {
-      R_nc_error (nc_strerror (status));
+      error (nc_strerror (status));
     }
 #else
     SET_VECTOR_ELT (result, 14, R_NilValue);
@@ -716,7 +716,7 @@ R_nc_inq_var (SEXP nc, SEXP var)
       SET_VECTOR_ELT (result, 16, ScalarInteger (NA_INTEGER));
       SET_VECTOR_ELT (result, 17, ScalarInteger (NA_INTEGER));
     } else {
-      R_nc_error (nc_strerror (status));
+      error (nc_strerror (status));
     }
 #else
     SET_VECTOR_ELT (result, 16, R_NilValue);

--- a/src/variable.c
+++ b/src/variable.c
@@ -528,14 +528,16 @@ R_nc_get_var (SEXP nc, SEXP var, SEXP start, SEXP count,
   R_nc_check (R_nc_enddef (ncid));
 
   /*-- Allocate memory and read variable from file ----------------------------*/
-  buf = R_nc_c2r_init (&io, NULL, ncid, xtype, ndims, ccount,
-                       israw, isfit, fillsize, fillp, minp, maxp, scalep, addp);
+  buf = NULL;
+  result = PROTECT(R_nc_c2r_init (&io, &buf, ncid, xtype, ndims, ccount,
+                     israw, isfit, fillsize, fillp, minp, maxp, scalep, addp));
 
   if (R_nc_length (ndims, ccount) > 0) {
     R_nc_check (nc_get_vara (ncid, varid, cstart, ccount, buf));
   }
-  result = R_nc_c2r (&io);
+  R_nc_c2r (&io);
 
+  UNPROTECT(1);
   return result;
 }
 


### PR DESCRIPTION
[CRAN](http://cran.r-project.org) runs [rchk](https://github.com/kalibera/rchk) on submitted packages, and RNetCDF_2.1 causes the following warning:

> Function R_nc_protect
>  [PB] has possible protection stack imbalance RNetCDF/src/common.c:49

This function wraps the `PROTECT` macro and increments a counter, which is used by the function `R_nc_unprotect` to call `UNPROTECT` at all exit points from the RNetCDF C code. According to the [rchk documentation](https://github.com/kalibera/cran-checks/blob/master/rchk/PROTECT.md), wrapping of `PROTECT`/`UNPROTECT` is discouraged.

This PR implements memory protection using the recommended caller-protects convention, relying on the R runtime to reset the protection stack after exceptions (e.g. `error`). The new implementation passes the tests in rchk (using the latest singularity container release), and all RNetCDF tests and examples succeed when running under gctorture and valgrind on R-3.6.1, built for Linux x86_64 with valgrind instrumentation.