### PR TITLE
Fix build failure for netcdf libraries without data64 support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RNetCDF
 Version: 2.4-1
-Date: 2020-07-25
+Date: 2020-08-27
 Title: Interface to 'NetCDF' Datasets
 Authors@R: c(person("Pavel", "Michna", role = "aut",
                     email = "rnetcdf-devel@bluewin.ch"),

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-Version 2.4-1, 2020-07-25
+Version 2.4-1, 2020-08-27
   * Support reading/writing special values (e.g. NA, Inf) without substitution,
     mainly in cases where type conversion between R and NetCDF is not required.
   * Fix selection of na.mode values 0,1,2

--- a/src/dataset.c
+++ b/src/dataset.c
@@ -166,7 +166,11 @@ R_nc_create (SEXP filename, SEXP clobber, SEXP share, SEXP prefill,
   } else if (R_nc_strcmp(format, "offset64")) {
     cmode = cmode | NC_64BIT_OFFSET;
   } else if (R_nc_strcmp(format, "data64")) {
+#ifdef NC_64BIT_DATA
     cmode = cmode | NC_64BIT_DATA;
+#else
+    error("NetCDF library does not support data64 format");
+#endif
   }
 
   /*-- Create the file --------------------------------------------------------*/

--- a/src/dataset.c
+++ b/src/dataset.c
@@ -60,10 +60,11 @@ R_nc_format2str (int format)
     return "classic";
 #ifdef NC_FORMAT_64BIT
   case NC_FORMAT_64BIT:
+    return "offset64";
 #elif defined NC_FORMAT_64BIT_OFFSET
   case NC_FORMAT_64BIT_OFFSET:
-#endif
     return "offset64";
+#endif
 #ifdef NC_FORMAT_64BIT_DATA
   case NC_FORMAT_64BIT_DATA:
     return "data64";


### PR DESCRIPTION
Use conditional compilation of data64 support in RNetCDF so that build succeeds with old netcdf libraries (tested with netcdf-4.1.3).