### PR TITLE
Add release script

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -21,6 +21,10 @@ thisdir="$( dirname "$0" )"
 basedir="$( cd "$thisdir/.." && pwd )"
 
 # Check that generated files are up-to-date:
+if test -n "$( git status --porcelain )"; then
+  echo "WARNING: uncommitted changes in package" >&2
+fi
+
 for file in configure configure.ac tools/convert.m4 src/convert.c ; do
   if test -n "$(git status --porcelain "$file")"; then
     echo "ERROR: $file has uncommitted changes" >&2

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Prepare for new RNetCDF release
+
+set -e
+set -u
+
+# Check inputs:
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 x.y-z" >&2
+  exit 1
+fi
+
+newver="$1"
+if ! echo "$newver" | grep -q '^[0-9]\+.[0-9]\+-[0-9]\+$' ; then
+  echo "ERROR: invalid format of release string" >&2
+  exit 1
+fi
+
+# Find base directory of package from location of this script:
+thisdir="$( dirname "$0" )"
+basedir="$( cd "$thisdir/.." && pwd )"
+
+# Check that generated files are up-to-date:
+if [[ "$basedir/configure.ac" -nt "$basedir/configure" ]]; then
+  echo "ERROR: configure.ac is newer than configure" >&2
+  exit 2
+fi
+
+if [[ "$basedir/tools/convert.m4" -nt "$basedir/src/convert.c" ]]; then
+  echo "ERROR: tools/convert.m4 is newer than src/convert.c" >&2
+  exit 3
+fi
+
+# Check that NEWS contains a description of the release:
+if ! grep -q "$newver" "$basedir/NEWS"; then
+  echo "WARNING: NEWS has no entry for release $newver" >&2
+fi
+
+# Get existing version string:
+oldver="$( grep 'Version: ' "$basedir/DESCRIPTION" | awk '{ print $2 }' )"
+
+# Replace version string in all files (excluding hidden files).
+# In-place option of sed is not portable between GNU and BSD versions.
+find "$basedir" -name '.*' -prune -o -type f -print | while read file; do
+    sed "s|$oldver|$newver|g" "$file" >"$file.sed"
+    mv "$file.sed" "$file"
+  done

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -20,6 +20,19 @@ fi
 thisdir="$( dirname "$0" )"
 cd "$thisdir/.."
 
+# Define function to convert date formats:
+if date -v 1d 2>/dev/null; then
+  # BSD date
+  DATEFMT() {
+    date -j -f '%Y-%m-%d %H:%M:%S %z' "$1" +%Y%m%d%H%M.%S
+  }
+else
+  # GNU date
+  DATEFMT() {
+    date -d "$1" +%Y%m%d%H%M.%S
+  }
+fi  
+
 # Check that generated files are up-to-date:
 if test -n "$( git status --porcelain )"; then
   echo "WARNING: uncommitted changes in package" >&2
@@ -32,7 +45,7 @@ for file in configure configure.ac tools/convert.m4 src/convert.c ; do
   else
     # Set timestamp on file to match last commit:
     time="$(git log --pretty=format:%cd -n 1 --date=iso -- "$file")"
-    time="$(date -j -f '%Y-%m-%d %H:%M:%S %z' "$time" +%Y%m%d%H%M.%S)"
+    time="$(DATEFMT "$time")"
     touch -m -t "$time" "$file"
   fi
 done

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -65,3 +65,8 @@ find . -mindepth 1 -name '.*' -prune -o -type f ! -name NEWS -print | while read
     fi
     mv "$file.sed" "$file"
   done
+
+# Update release date in DESCRIPTION:
+newdate="$( date +%Y-%m-%d )"
+sed "s|Date:.*|Date: $newdate|" DESCRIPTION >DESCRIPTION.sed
+mv DESCRIPTION.sed DESCRIPTION

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -21,7 +21,7 @@ thisdir="$( dirname "$0" )"
 cd "$thisdir/.."
 
 # Define function to convert date formats:
-if date -v 1d 2>/dev/null; then
+if date -v 1d >/dev/null 2>&1; then
   # BSD date
   DATEFMT() {
     date -j -f '%Y-%m-%d %H:%M:%S %z' "$1" +%Y%m%d%H%M.%S

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -57,7 +57,7 @@ oldver="$( grep 'Version: ' DESCRIPTION | awk '{ print $2 }' )"
 
 # Replace version string in all files (excluding hidden files).
 # In-place option of sed is not portable between GNU and BSD versions.
-find . -mindepth 1 -name '.*' -prune -o -type f -print | while read file; do
+find . -mindepth 1 -name '.*' -prune -o -type f ! -name NEWS -print | while read file; do
     sed "s|$oldver|$newver|g" "$file" >"$file.sed"
     if [[ -x "$file" ]]; then
       # Preserve execute permissions:

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -55,5 +55,9 @@ oldver="$( grep 'Version: ' "$basedir/DESCRIPTION" | awk '{ print $2 }' )"
 # In-place option of sed is not portable between GNU and BSD versions.
 find "$basedir" -name '.*' -prune -o -type f -print | while read file; do
     sed "s|$oldver|$newver|g" "$file" >"$file.sed"
+    if [[ -x "$file" ]]; then
+      # Preserve execute permissions:
+      chmod +x "$file.sed"
+    fi
     mv "$file.sed" "$file"
   done

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -21,6 +21,18 @@ thisdir="$( dirname "$0" )"
 basedir="$( cd "$thisdir/.." && pwd )"
 
 # Check that generated files are up-to-date:
+for file in configure configure.ac tools/convert.m4 src/convert.c ; do
+  if test -n "$(git status --porcelain "$file")"; then
+    echo "ERROR: $file has uncommitted changes" >&2
+    exit 2
+  else
+    # Set timestamp on file to match last commit:
+    time="$(git log --pretty=format:%cd -n 1 --date=iso -- "$file")"
+    time="$(date -j -f '%Y-%m-%d %H:%M:%S %z' "$time" +%Y%m%d%H%M.%S)"
+    touch -m -t "$time" "$file"
+  fi
+done
+
 if [[ "$basedir/configure.ac" -nt "$basedir/configure" ]]; then
   echo "ERROR: configure.ac is newer than configure" >&2
   exit 2

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -44,7 +44,7 @@ for file in configure configure.ac tools/convert.m4 src/convert.c ; do
     exit 2
   else
     # Set timestamp on file to match last commit:
-    time="$(git log --pretty=format:%cd -n 1 --date=iso -- "$file")"
+    time="$(git log --pretty=format:%ad -n 1 --date=iso -- "$file")"
     time="$(DATEFMT "$time")"
     touch -m -t "$time" "$file"
   fi

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -16,9 +16,9 @@ if ! echo "$newver" | grep -q '^[0-9]\+.[0-9]\+-[0-9]\+$' ; then
   exit 1
 fi
 
-# Find base directory of package from location of this script:
+# Set working directory to base directory of package:
 thisdir="$( dirname "$0" )"
-basedir="$( cd "$thisdir/.." && pwd )"
+cd "$thisdir/.."
 
 # Check that generated files are up-to-date:
 if test -n "$( git status --porcelain )"; then
@@ -37,27 +37,27 @@ for file in configure configure.ac tools/convert.m4 src/convert.c ; do
   fi
 done
 
-if [[ "$basedir/configure.ac" -nt "$basedir/configure" ]]; then
+if [[ "configure.ac" -nt "configure" ]]; then
   echo "ERROR: configure.ac is newer than configure" >&2
   exit 2
 fi
 
-if [[ "$basedir/tools/convert.m4" -nt "$basedir/src/convert.c" ]]; then
+if [[ "tools/convert.m4" -nt "src/convert.c" ]]; then
   echo "ERROR: tools/convert.m4 is newer than src/convert.c" >&2
   exit 3
 fi
 
 # Check that NEWS contains a description of the release:
-if ! grep -q "$newver" "$basedir/NEWS"; then
+if ! grep -q "$newver" NEWS; then
   echo "WARNING: NEWS has no entry for release $newver" >&2
 fi
 
 # Get existing version string:
-oldver="$( grep 'Version: ' "$basedir/DESCRIPTION" | awk '{ print $2 }' )"
+oldver="$( grep 'Version: ' DESCRIPTION | awk '{ print $2 }' )"
 
 # Replace version string in all files (excluding hidden files).
 # In-place option of sed is not portable between GNU and BSD versions.
-find "$basedir" -name '.*' -prune -o -type f -print | while read file; do
+find . -mindepth 1 -name '.*' -prune -o -type f -print | while read file; do
     sed "s|$oldver|$newver|g" "$file" >"$file.sed"
     if [[ -x "$file" ]]; then
       # Preserve execute permissions:


### PR DESCRIPTION
Add new script tools/release.sh to set package version in files and perform various checks, such as ensuring that generated files are up-to-date.