### PR TITLE
Support hdf5 filters via multi-filter interface

### DIFF
--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -493,8 +493,8 @@ sync.nc <- function(ncfile) {
 var.def.nc <- function(ncfile, varname, vartype, dimensions,
                        chunking=NA, chunksizes=NULL,
                        deflate=NA, shuffle=FALSE, big_endian=NA,
-                       fletcher32=FALSE, filter_id=NA,
-                       filter_params=integer(0)) {
+                       fletcher32=FALSE, filter_id=integer(0),
+                       filter_params=list()) {
   #-- Check args -------------------------------------------------------------
   stopifnot(class(ncfile) == "NetCDF")
   stopifnot(is.character(varname))
@@ -511,8 +511,10 @@ var.def.nc <- function(ncfile, varname, vartype, dimensions,
   stopifnot(is.logical(shuffle))
   stopifnot(is.logical(big_endian))
   stopifnot(is.logical(fletcher32))
-  stopifnot(isTRUE(is.na(filter_id)) || is.numeric(filter_id))
-  stopifnot(is.integer(filter_params))
+  stopifnot(is.numeric(filter_id))
+  stopifnot(is.list(filter_params))
+  stopifnot(all(sapply(filter_params, FUN=is.numeric)))
+  stopifnot(length(filter_id) == length(filter_params))
 
   #-- C function call --------------------------------------------------------
   nc <- .Call(R_nc_def_var, ncfile, varname, vartype, dimensions,

--- a/configure
+++ b/configure
@@ -3843,6 +3843,12 @@ then :
   printf "%s\n" "#define HAVE_NC_INQ_VAR_ENDIAN 1" >>confdefs.h
 
 fi
+ac_fn_c_check_func "$LINENO" "nc_def_var_filter" "ac_cv_func_nc_def_var_filter"
+if test "x$ac_cv_func_nc_def_var_filter" = xyes
+then :
+  printf "%s\n" "#define HAVE_NC_DEF_VAR_FILTER 1" >>confdefs.h
+
+fi
 ac_fn_c_check_func "$LINENO" "nc_inq_var_filter_ids" "ac_cv_func_nc_inq_var_filter_ids"
 if test "x$ac_cv_func_nc_inq_var_filter_ids" = xyes
 then :

--- a/configure
+++ b/configure
@@ -3843,10 +3843,16 @@ then :
   printf "%s\n" "#define HAVE_NC_INQ_VAR_ENDIAN 1" >>confdefs.h
 
 fi
-ac_fn_c_check_func "$LINENO" "nc_inq_var_filter" "ac_cv_func_nc_inq_var_filter"
-if test "x$ac_cv_func_nc_inq_var_filter" = xyes
+ac_fn_c_check_func "$LINENO" "nc_inq_var_filter_ids" "ac_cv_func_nc_inq_var_filter_ids"
+if test "x$ac_cv_func_nc_inq_var_filter_ids" = xyes
 then :
-  printf "%s\n" "#define HAVE_NC_INQ_VAR_FILTER 1" >>confdefs.h
+  printf "%s\n" "#define HAVE_NC_INQ_VAR_FILTER_IDS 1" >>confdefs.h
+
+fi
+ac_fn_c_check_func "$LINENO" "nc_inq_var_filter_info" "ac_cv_func_nc_inq_var_filter_info"
+if test "x$ac_cv_func_nc_inq_var_filter_info" = xyes
+then :
+  printf "%s\n" "#define HAVE_NC_INQ_VAR_FILTER_INFO 1" >>confdefs.h
 
 fi
 ac_fn_c_check_func "$LINENO" "nc_create_par_fortran" "ac_cv_func_nc_create_par_fortran"
@@ -3869,7 +3875,7 @@ then :
 fi
 
 
-# Check for parallel I/O support.
+# Check for parallel header file.
 ac_fn_c_check_header_compile "$LINENO" "netcdf_par.h" "ac_cv_header_netcdf_par_h" "#include <netcdf.h>
 "
 if test "x$ac_cv_header_netcdf_par_h" = xyes
@@ -3877,6 +3883,17 @@ then :
   printf "%s\n" "#define HAVE_NETCDF_PAR_H 1" >>confdefs.h
 
 fi
+
+
+# Check for filter header file.
+ac_fn_c_check_header_compile "$LINENO" "netcdf_filter.h" "ac_cv_header_netcdf_filter_h" "#include <netcdf.h>
+"
+if test "x$ac_cv_header_netcdf_filter_h" = xyes
+then :
+  printf "%s\n" "#define HAVE_NETCDF_FILTER_H 1" >>confdefs.h
+
+fi
+
 
 
 #-------------------------------------------------------------------------------#

--- a/configure.ac
+++ b/configure.ac
@@ -68,11 +68,15 @@ AC_SEARCH_LIBS(nc_open, netcdf, [],
 # Check for the existence of optional netcdf routines.
 # C preprocessor macros HAVE_routine are defined for existing routines.
 AC_CHECK_FUNCS([nc_rename_grp nc_get_var_chunk_cache nc_inq_var_szip \
-  nc_inq_var_endian nc_inq_var_filter \
+  nc_inq_var_endian nc_inq_var_filter_ids nc_inq_var_filter_info \
   nc_create_par_fortran nc_open_par_fortran nc_var_par_access])
 
-# Check for parallel I/O support.
+# Check for parallel header file.
 AC_CHECK_HEADERS(netcdf_par.h, [], [], [#include <netcdf.h>])
+
+# Check for filter header file.
+AC_CHECK_HEADERS(netcdf_filter.h, [], [], [#include <netcdf.h>])
+
 
 #-------------------------------------------------------------------------------#
 #  Find UDUNITS2 library and header files                                       #

--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,7 @@ AC_SEARCH_LIBS(nc_open, netcdf, [],
 # Check for the existence of optional netcdf routines.
 # C preprocessor macros HAVE_routine are defined for existing routines.
 AC_CHECK_FUNCS([nc_rename_grp nc_get_var_chunk_cache nc_inq_var_szip \
-  nc_inq_var_endian nc_inq_var_filter_ids nc_inq_var_filter_info \
+  nc_inq_var_endian nc_def_var_filter nc_inq_var_filter_ids nc_inq_var_filter_info \
   nc_create_par_fortran nc_open_par_fortran nc_var_par_access])
 
 # Check for parallel header file.

--- a/man/var.def.nc.Rd
+++ b/man/var.def.nc.Rd
@@ -23,8 +23,8 @@
   \item{shuffle}{\code{TRUE} to enable byte shuffling, which may improve compression with \code{deflate}.}
   \item{big_endian}{Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for native endianness of the platform.}
   \item{fletcher32}{\code{TRUE} to enable the fletcher32 checksum.}
-  \item{filter_id}{Vector of filter IDs to associate with the variable (empty vector denotes no filters). For information about the available filters, please see the NetCDF documentation. Ignored if the installed NetCDF library does not support this feature.}
-  \item{filter_params}{List with one element for each \code{filter_id}. Each list member is a vector of \code{numeric} parameters (which are converted to unsigned integers). The meaning of the parameters depends on the filter implementation, and RNetCDF is unable to perform any validation. Ignored if the installed NetCDF library does not support this feature.}
+  \item{filter_id}{Vector of filter IDs to associate with the variable (empty vector denotes no filters). For information about the available filters, please see the NetCDF documentation. An error is raised if filters are specified when the installed NetCDF library does not support the multi-filter interface.}
+  \item{filter_params}{List with one element for each \code{filter_id}. Each list member is a vector of \code{numeric} parameters (which are converted to unsigned integers). The meaning of the parameters depends on the filter implementation, and RNetCDF is unable to perform any validation.}
 }
 
 \value{NetCDF variable identifier, returned invisibly.}

--- a/man/var.def.nc.Rd
+++ b/man/var.def.nc.Rd
@@ -23,8 +23,8 @@
   \item{shuffle}{\code{TRUE} to enable byte shuffling, which may improve compression with \code{deflate}.}
   \item{big_endian}{Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for native endianness of the platform.}
   \item{fletcher32}{\code{TRUE} to enable the fletcher32 checksum.}
-  \item{filter_id}{Vector of filter IDs to associate with the variable (empty vector denotes no filters). For information about the available filters, please see the NetCDF documentation. An error is raised if filters are specified when the installed NetCDF library does not support the multi-filter interface.}
-  \item{filter_params}{List with one element for each \code{filter_id}. Each list member is a vector of \code{numeric} parameters (which are converted to unsigned integers). The meaning of the parameters depends on the filter implementation, and RNetCDF is unable to perform any validation.}
+  \item{filter_id}{Vector of filter IDs to associate with the variable (empty vector denotes no filters). For information about the available filters, please see the NetCDF documentation. Ignored if the installed NetCDF library does not support the multi-filter interface.}
+  \item{filter_params}{List with one element for each \code{filter_id}. Each list member is a vector of \code{numeric} parameters (which are converted to unsigned integers). The meaning of the parameters depends on the filter implementation, and RNetCDF is unable to perform any validation. Ignored if the installed NetCDF library does not support the multi-filter interface.}
 }
 
 \value{NetCDF variable identifier, returned invisibly.}

--- a/man/var.def.nc.Rd
+++ b/man/var.def.nc.Rd
@@ -24,7 +24,7 @@
   \item{big_endian}{Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for native endianness of the platform.}
   \item{fletcher32}{\code{TRUE} to enable the fletcher32 checksum.}
   \item{filter_id}{Vector of filter IDs to associate with the variable (empty vector denotes no filters). For information about the available filters, please see the NetCDF documentation. Ignored if the installed NetCDF library does not support this feature.}
-  \item{filter_params}{List with one element for each \code{filter_id}. Each list member is a vector of \code{numeric} parameters. The meaning of the parameters depends on the filter implementation, and RNetCDF is unable to perform any validation. Ignored if the installed NetCDF library does not support this feature.}
+  \item{filter_params}{List with one element for each \code{filter_id}. Each list member is a vector of \code{numeric} parameters (which are converted to unsigned integers). The meaning of the parameters depends on the filter implementation, and RNetCDF is unable to perform any validation. Ignored if the installed NetCDF library does not support this feature.}
 }
 
 \value{NetCDF variable identifier, returned invisibly.}

--- a/man/var.def.nc.Rd
+++ b/man/var.def.nc.Rd
@@ -9,7 +9,7 @@
 \usage{var.def.nc(ncfile, varname, vartype, dimensions,
                   chunking=NA, chunksizes=NULL, deflate=NA, shuffle=FALSE,
                   big_endian=NA, fletcher32=FALSE,
-                  filter_id=NA, filter_params=integer(0))}
+                  filter_id=integer(0), filter_params=list())}
 
 \arguments{
   \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
@@ -23,8 +23,8 @@
   \item{shuffle}{\code{TRUE} to enable byte shuffling, which may improve compression with \code{deflate}.}
   \item{big_endian}{Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for native endianness of the platform.}
   \item{fletcher32}{\code{TRUE} to enable the fletcher32 checksum.}
-  \item{filter_id}{Identifier of filter to associate with the variable, or \code{NA} for no filter. For information about the available filters, please see the NetCDF documentation. Ignored if the installed NetCDF library does not support this feature.}
-  \item{filter_params}{Vector of \code{integer} parameters for the filter specified by \code{filter_id}. The meaning of the parameters depends on the filter implementation, and RNetCDF is unable to perform any validation. Ignored if no filter is defined or if the installed NetCDF library does not support this feature.}
+  \item{filter_id}{Vector of filter IDs to associate with the variable (empty vector denotes no filters). For information about the available filters, please see the NetCDF documentation. Ignored if the installed NetCDF library does not support this feature.}
+  \item{filter_params}{List with one element for each \code{filter_id}. Each list member is a vector of \code{numeric} parameters. The meaning of the parameters depends on the filter implementation, and RNetCDF is unable to perform any validation. Ignored if the installed NetCDF library does not support this feature.}
 }
 
 \value{NetCDF variable identifier, returned invisibly.}

--- a/man/var.inq.nc.Rd
+++ b/man/var.inq.nc.Rd
@@ -35,7 +35,7 @@ The list components below apply only to datasets in "netcdf4" format:
   \item{szip_options}{Integer containing a bitmask of szip options. \code{NA} if szip is not used, or \code{NULL} if unsupported.}
   \item{szip_bits}{Number of bits per pixel for szip. \code{NA} if szip is not used, or \code{NULL} if unsupported.}
   \item{filter_id}{Vector of filter IDs associated with the variable, or \code{NULL} if the NetCDF library does not support filters.}
-  \item{filter_params}{List with one element per \code{filter_id}, or \code{NULL} if the NetCDF library does not support filters. Each list member is a vector of parameters for the corresponding filter. Please see the NetCDF documentation for information about the available filters and their parameters.}
+  \item{filter_params}{List with one element per \code{filter_id}, or \code{NULL} if the NetCDF library does not support filters. Each list member is a vector of \code{numeric} parameters for the corresponding filter. Please see the NetCDF documentation for information about the available filters and their parameters.}
 }
 
 \details{This function returns information about a NetCDF variable. Information about a variable include its name, its ID, its type, its number of dimensions, a vector of the dimension IDs of this variable and the number of attributes.}

--- a/man/var.inq.nc.Rd
+++ b/man/var.inq.nc.Rd
@@ -34,8 +34,8 @@ The list components below apply only to datasets in "netcdf4" format:
   \item{fletcher32}{\code{TRUE} if the fletcher32 checksum is enabled for this variable, \code{FALSE} otherwise.}
   \item{szip_options}{Integer containing a bitmask of szip options. \code{NA} if szip is not used, or \code{NULL} if unsupported.}
   \item{szip_bits}{Number of bits per pixel for szip. \code{NA} if szip is not used, or \code{NULL} if unsupported.}
-  \item{filter_id}{Vector of filter IDs associated with the variable, or \code{NULL} if the NetCDF library does not support filters.}
-  \item{filter_params}{List with one element per \code{filter_id}, or \code{NULL} if the NetCDF library does not support filters. Each list member is a vector of \code{numeric} parameters for the corresponding filter. Please see the NetCDF documentation for information about the available filters and their parameters.}
+  \item{filter_id}{Vector of filter IDs associated with the variable, or \code{NULL} if the NetCDF library does not support the multi-filter interface.}
+  \item{filter_params}{List with one element per \code{filter_id}, or \code{NULL} if the NetCDF library does not support the multi-filter interface. Each list member is a vector of \code{numeric} parameters for the corresponding filter. Please see the NetCDF documentation for information about the available filters and their parameters.}
 }
 
 \details{This function returns information about a NetCDF variable. Information about a variable include its name, its ID, its type, its number of dimensions, a vector of the dimension IDs of this variable and the number of attributes.}

--- a/man/var.inq.nc.Rd
+++ b/man/var.inq.nc.Rd
@@ -22,7 +22,7 @@
   \item{dimids}{Vector of dimension IDs corresponding to the variable dimensions (\code{NA} for scalar variables). Order is leftmost varying fastest.}
   \item{natts}{Number of variable attributes assigned to this variable.}
 
-The arguments below apply only to datasets in "netcdf4" format:
+The list components below apply only to datasets in "netcdf4" format:
 
   \item{chunksizes}{Chunk size expressed as the number of elements along each dimension, in the same order as \code{dimids}. \code{NULL} implies contiguous storage.}
   \item{cache_bytes}{Size of chunk cache in bytes (\code{NULL} if unsupported).}
@@ -34,8 +34,8 @@ The arguments below apply only to datasets in "netcdf4" format:
   \item{fletcher32}{\code{TRUE} if the fletcher32 checksum is enabled for this variable, \code{FALSE} otherwise.}
   \item{szip_options}{Integer containing a bitmask of szip options. \code{NA} if szip is not used, or \code{NULL} if unsupported.}
   \item{szip_bits}{Number of bits per pixel for szip. \code{NA} if szip is not used, or \code{NULL} if unsupported.}
-  \item{filter_id}{Identifier of filter associated with the variable. \code{NA} if no filter is defined, or \code{NULL} if unsupported.}
-  \item{filter_params}{Vector of integer parameters for the filter associated with the variable. \code{NA} if no filter is defined, or \code{NULL} if unsupported.}
+  \item{filter_id}{Vector of filter IDs associated with the variable, or \code{NULL} if the NetCDF library does not support filters.}
+  \item{filter_params}{List with one element per \code{filter_id}, or \code{NULL} if the NetCDF library does not support filters. Each list member is a vector of parameters for the corresponding filter. Please see the NetCDF documentation for information about the available filters and their parameters.}
 }
 
 \details{This function returns information about a NetCDF variable. Information about a variable include its name, its ID, its type, its number of dimensions, a vector of the dimension IDs of this variable and the number of attributes.}

--- a/src/common.c
+++ b/src/common.c
@@ -292,61 +292,6 @@ R_nc_strarg (SEXP str)
 }
 
 
-size_t
-R_nc_sizearg (SEXP size)
-{
-  int erange=0;
-  size_t result=0;
-  if (xlength (size) > 0) {
-    if (TYPEOF (size) == INTSXP) {
-      int ival;
-      unsigned int uival;
-      ival = INTEGER (size)[0];
-      uival = ival;
-#if SIZEOF_INT > SIZEOF_SIZE_T
-      erange = (ival == NA_INTEGER || ival < 0 || uival > SIZE_MAX);
-#else
-      erange = (ival == NA_INTEGER || ival < 0);
-#endif
-      if (!erange) {
-        result = uival;
-      }
-    } else if (TYPEOF (size) == REALSXP) {
-      if (R_nc_inherits (size, "integer64")) {
-        long long llval;
-        unsigned long long ullval;
-        llval = *(long long *) REAL (size);
-        ullval = llval;
-        /* Assume integer64 can represent size of any object without wrapping */
-#if SIZEOF_LONG_LONG > SIZEOF_SIZE_T
-        erange = (llval == NA_INTEGER64 || llval < 0 || ullval > SIZE_MAX);
-#else
-        erange = (llval == NA_INTEGER64 || llval < 0);
-#endif
-        if (!erange) {
-          result = ullval;
-        }
-      } else {
-        double dval;
-        dval = REAL (size)[0];
-        erange = (! R_FINITE (dval) || dval < 0 || dval > SIZE_MAX);
-        if (!erange) {
-          result = dval;
-        }
-      }
-    } else {
-      error ("Size argument has unsupported R type");
-    }
-  } else {
-    error ("Size argument must contain at least one numeric value");
-  }
-  if (erange) {
-    error ("Size argument is outside valid range");
-  }
-  return result;
-}
-
-
 int
 R_nc_redef (int ncid)
 {

--- a/src/common.h
+++ b/src/common.h
@@ -40,11 +40,6 @@
   #define NC_MAX_ATOMIC_TYPE NC_STRING
 #endif
 
-#define NA_SIZE SIZE_MAX
-
-/* Definition of missing value used by bit64 package */
-#define NA_INTEGER64 LLONG_MIN
-
 /* Common error strings */
 static const char RNC_EDATALEN[]="Not enough data", \
   RNC_EDATATYPE[]="Incompatible data for external type", \
@@ -103,13 +98,6 @@ R_nc_str2type (int ncid, const char *str, nc_type * xtype);
  */
 const char *
 R_nc_strarg (SEXP str);
-
-
-/* Convert R numeric scalar argument to size_t.
-   Raise an error if R type or value is not compatible.
- */
-size_t
-R_nc_sizearg (SEXP size);
 
 
 /* Enter netcdf define mode if possible.

--- a/src/convert.c
+++ b/src/convert.c
@@ -56,6 +56,10 @@
  *  Local macros, constants and variables
 \*=============================================================================*/
 
+/* Definition of missing value used by bit64 package */
+#define NA_INTEGER64 LLONG_MIN
+
+/* Maximum length of R character string */
 #define RNC_CHARSXP_MAXLEN 2147483647
 
 /* Conversion from 64-bit integers to double may round upwards,
@@ -7489,3 +7493,15 @@ R_nc_dim_r2c_size (SEXP rv, size_t N, size_t fillval)
 
 
 
+/* Wrap R_nc_dim_r2c_size for scalar arguments
+ */
+size_t
+R_nc_sizearg (SEXP size)
+{
+  size_t *result;
+  if (xlength (size) < 1) {
+    error ("Size argument must contain at least one numeric value");
+  }
+  result = R_nc_dim_r2c_size (size, 1, 0);
+  return *result;
+}

--- a/src/convert.h
+++ b/src/convert.h
@@ -132,5 +132,12 @@ R_NC_DIM_R2C_H (R_nc_dim_r2c_int, int)
 R_NC_DIM_R2C_H (R_nc_dim_r2c_size, size_t)
 
 
+/* Convert R numeric scalar argument to size_t.
+   Raise an error if R type or value is not compatible.
+ */
+size_t
+R_nc_sizearg (SEXP size);
+
+
 #endif /* RNC_CONVERT_H_INCLUDED */
 

--- a/src/dimension.c
+++ b/src/dimension.c
@@ -44,6 +44,7 @@
 #include <netcdf.h>
 
 #include "common.h"
+#include "convert.h"
 #include "RNetCDF.h"
 
 

--- a/src/variable.c
+++ b/src/variable.c
@@ -165,12 +165,12 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
       R_nc_check (nc_def_var_fletcher32 (ncid, varid, fletcher_mode));
     }
 
+    nfilter = xlength (filter_id);
+    if (nfilter > 0) {
 #ifdef HAVE_NC_DEF_VAR_FILTER
     /* Convert filter_id to unsigned int;
        memory is allocated by R_alloc and automatically freed.
      */
-    nfilter = xlength (filter_id);
-    if (nfilter > 0) {
       ufiltid = (unsigned int *) R_nc_r2c (
         filter_id, ncid, NC_UINT, 1, &nfilter, 0, NULL, NULL, NULL);
 
@@ -186,8 +186,10 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
 	/* Define a filter for the netcdf variable */
 	R_nc_check (nc_def_var_filter (ncid, varid, ufiltid[ifilter], nfiltparm, ufiltparm));
       }
-    }
+#else
+      error("nc_def_var_filter not supported by netcdf library");
 #endif
+    }
   }
 
   return ScalarInteger (varid);

--- a/src/variable.c
+++ b/src/variable.c
@@ -68,7 +68,7 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
 {
   int ncid, ii, jj, *dimids, ndims, varid, chunkmode, format, withnc4;
   int deflate_mode, deflate_level, shuffle_mode, fletcher_mode;
-  size_t *chunksize_t;
+  size_t *chunksize_t, nfilter;
   nc_type xtype;
   const char *varnamep;
 
@@ -77,7 +77,7 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
 #endif
 #ifdef HAVE_NC_DEF_VAR_FILTER
   unsigned int *ufiltid, *ufiltparm;
-  size_t ifilter, nfilter, nfiltparm;
+  size_t ifilter, nfiltparm;
   SEXP rfiltparm;
 #endif
 

--- a/src/variable.c
+++ b/src/variable.c
@@ -628,7 +628,7 @@ R_nc_inq_var (SEXP nc, SEXP var)
 #endif
 #if defined HAVE_NC_INQ_VAR_FILTER_IDS && defined HAVE_NC_INQ_VAR_FILTER_INFO
   R_nc_buf filtio;
-  double *dfiltid, *dfiltparm;
+  double *dfiltid;
   unsigned int *ufiltid, *ufiltparm;
   size_t ifilter, nfilter, nfiltparm;
   SEXP rfilter_id, rfilter_params, rfiltparm;

--- a/src/variable.c
+++ b/src/variable.c
@@ -791,7 +791,7 @@ R_nc_inq_var (SEXP nc, SEXP var)
 	  R_nc_check (nc_inq_var_filter_info (ncid, varid, ufiltid[ifilter], &nfiltparm, NULL));
 	  ufiltparm = NULL;
 	  rfiltparm = PROTECT (R_nc_c2r_init (&filtio, (void **) &ufiltparm,
-	    ncid, NC_UINT, 1, &nfiltparm, 0, 0, 0,
+	    ncid, NC_UINT, -1, &nfiltparm, 0, 0, 0,
 	    NULL, NULL, NULL, NULL, NULL));
 	  SET_VECTOR_ELT (rfilter_params, ifilter, rfiltparm);
 	  UNPROTECT(1);

--- a/src/variable.c
+++ b/src/variable.c
@@ -191,8 +191,9 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
 	/* Define a filter for the netcdf variable */
 	R_nc_check (nc_def_var_filter (ncid, varid, ufiltid[ifilter], nfiltparm, ufiltparm));
       }
-#endif
     }
+
+#endif
   }
 
   return ScalarInteger (varid);

--- a/src/variable.c
+++ b/src/variable.c
@@ -73,7 +73,7 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
 {
   int ncid, ii, jj, *dimids, ndims, varid, chunkmode, format, withnc4;
   int deflate_mode, deflate_level, shuffle_mode, fletcher_mode;
-  size_t *chunksize_t, nfilter;
+  size_t *chunksize_t;
   nc_type xtype;
   const char *varnamep;
 
@@ -82,7 +82,7 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
 #endif
 #ifdef HAVE_NC_MULTI_FILTER
   unsigned int *ufiltid, *ufiltparm;
-  size_t ifilter, nfiltparm;
+  size_t ifilter, nfilter, nfiltparm;
   SEXP rfiltparm;
 #endif
 
@@ -170,9 +170,9 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
       R_nc_check (nc_def_var_fletcher32 (ncid, varid, fletcher_mode));
     }
 
+#ifdef HAVE_NC_MULTI_FILTER
     nfilter = xlength (filter_id);
     if (nfilter > 0) {
-#ifdef HAVE_NC_MULTI_FILTER
     /* Convert filter_id to unsigned int;
        memory is allocated by R_alloc and automatically freed.
      */
@@ -191,8 +191,6 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
 	/* Define a filter for the netcdf variable */
 	R_nc_check (nc_def_var_filter (ncid, varid, ufiltid[ifilter], nfiltparm, ufiltparm));
       }
-#else
-      error("Multi-filter interface not supported by netcdf library");
 #endif
     }
   }

--- a/src/variable.c
+++ b/src/variable.c
@@ -55,6 +55,11 @@
 #include <netcdf_filter.h>
 #endif
 
+#if defined HAVE_NC_DEF_VAR_FILTER && \
+    defined HAVE_NC_INQ_VAR_FILTER_IDS && \
+    defined HAVE_NC_INQ_VAR_FILTER_INFO
+#define HAVE_NC_MULTI_FILTER
+#endif
 
 /*-----------------------------------------------------------------------------*\
  *  R_nc_def_var()
@@ -75,7 +80,7 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
 #ifdef HAVE_NC_INQ_VAR_ENDIAN
   int endian_mode;
 #endif
-#ifdef HAVE_NC_DEF_VAR_FILTER
+#ifdef HAVE_NC_MULTI_FILTER
   unsigned int *ufiltid, *ufiltparm;
   size_t ifilter, nfiltparm;
   SEXP rfiltparm;
@@ -167,7 +172,7 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
 
     nfilter = xlength (filter_id);
     if (nfilter > 0) {
-#ifdef HAVE_NC_DEF_VAR_FILTER
+#ifdef HAVE_NC_MULTI_FILTER
     /* Convert filter_id to unsigned int;
        memory is allocated by R_alloc and automatically freed.
      */
@@ -187,7 +192,7 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
 	R_nc_check (nc_def_var_filter (ncid, varid, ufiltid[ifilter], nfiltparm, ufiltparm));
       }
 #else
-      error("nc_def_var_filter not supported by netcdf library");
+      error("Multi-filter interface not supported by netcdf library");
 #endif
     }
   }
@@ -626,7 +631,7 @@ R_nc_inq_var (SEXP nc, SEXP var)
 #ifdef HAVE_NC_INQ_VAR_SZIP
   int szip_options, szip_bits;
 #endif
-#if defined HAVE_NC_INQ_VAR_FILTER_IDS && defined HAVE_NC_INQ_VAR_FILTER_INFO
+#ifdef HAVE_NC_MULTI_FILTER
   R_nc_buf filtio;
   double *dfiltid;
   unsigned int *ufiltid, *ufiltparm;
@@ -762,7 +767,7 @@ R_nc_inq_var (SEXP nc, SEXP var)
 #endif
 
     /* filter */
-#if defined HAVE_NC_INQ_VAR_FILTER_IDS && HAVE_NC_INQ_VAR_FILTER_INFO
+#ifdef HAVE_NC_MULTI_FILTER
     if (storeprop == NC_CHUNKED) {
       /* Query number of filters for the variable */
       R_nc_check (nc_inq_var_filter_ids (ncid, varid, &nfilter, NULL));

--- a/src/variable.c
+++ b/src/variable.c
@@ -51,6 +51,10 @@
 #include <netcdf_par.h>
 #endif
 
+#ifdef HAVE_NETCDF_FILTER_H
+#include <netcdf_filter.h>
+#endif
+
 
 /*-----------------------------------------------------------------------------*\
  *  R_nc_def_var()
@@ -71,8 +75,10 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
 #ifdef HAVE_NC_INQ_VAR_ENDIAN
   int endian_mode;
 #endif
-#ifdef HAVE_NC_INQ_VAR_FILTER
-  int filter_mode, filtid, *filtparm;
+#ifdef HAVE_NC_DEF_VAR_FILTER
+  unsigned int *ufiltid, *ufiltparm;
+  size_t ifilter, nfilter;
+  SEXP rfiltparm;
 #endif
 
   /*-- Convert arguments to netcdf ids ----------------------------------------*/
@@ -128,11 +134,6 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
 
     fletcher_mode = (asLogical (fletcher32) == TRUE);
 
-#ifdef HAVE_NC_INQ_VAR_FILTER
-    filtid = asInteger (filter_id);
-    filter_mode = (filtid != NA_INTEGER);
-    filtparm = INTEGER (filter_params);
-#endif
   }
 
   /*-- Enter define mode ------------------------------------------------------*/
@@ -164,10 +165,25 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
       R_nc_check (nc_def_var_fletcher32 (ncid, varid, fletcher_mode));
     }
 
-#ifdef HAVE_NC_INQ_VAR_FILTER
-    if (filter_mode) {
-      R_nc_check (nc_def_var_filter (ncid, varid, (unsigned int) filtid,
-        xlength (filter_params), (const unsigned int*) filtparm));
+#ifdef HAVE_NC_DEF_VAR_FILTER
+    /* Convert filter_id to unsigned int;
+       memory is allocated by R_alloc and automatically freed.
+     */
+    nfilter = xlength (filter_id);
+    ufiltid = (unsigned int *) R_nc_r2c (
+        filter_id, ncid, NC_UINT, 1, &nfilter, 0, NULL, NULL, NULL);
+
+    for (ifilter=0; ifilter<nfilter; ifilter++) {
+      /* Convert filter_params to unsigned int;
+         memory is allocated by R_alloc and automatically freed.
+       */
+      rfiltparm = VECTOR_ELT (filter_params, ifilter);
+      nfiltparm = xlength (rfiltparm);
+      ufiltparm = (unsigned int *) R_nc_r2c (
+        rfiltparm, ncid, NC_UINT, 1, &nfiltparm, 0, NULL, NULL, NULL);
+
+      /* Define a filter for the netcdf variable */
+      R_nc_check (nc_def_var_filter (ncid, varid, ufiltid[ifilter], nfiltparm, ufiltparm));
     }
 #endif
   }
@@ -606,10 +622,12 @@ R_nc_inq_var (SEXP nc, SEXP var)
 #ifdef HAVE_NC_INQ_VAR_SZIP
   int szip_options, szip_bits;
 #endif
-#ifdef HAVE_NC_INQ_VAR_FILTER
-  int filter_id;
-  size_t filter_nparams;
-  SEXP rfilter_params;
+#if defined HAVE_NC_INQ_VAR_FILTER_IDS && defined HAVE_NC_INQ_VAR_FILTER_INFO
+  R_nc_buf filtio;
+  double *dfiltid, *dfiltparm;
+  unsigned int *ufiltid, *ufiltparm;
+  size_t ifilter, nfilter, nfiltparm;
+  SEXP rfilter_id, rfilter_params, rfiltparm;
 #endif
 
   /*-- Convert arguments to netcdf ids ----------------------------------------*/
@@ -740,39 +758,48 @@ R_nc_inq_var (SEXP nc, SEXP var)
 #endif
 
     /* filter */
-#ifdef HAVE_NC_INQ_VAR_FILTER
+#if defined HAVE_NC_INQ_VAR_FILTER_IDS && HAVE_NC_INQ_VAR_FILTER_INFO
     if (storeprop == NC_CHUNKED) {
-      status = nc_inq_var_filter (ncid, varid,
-                                  (unsigned int *) &filter_id,
-                                  &filter_nparams, NULL);
-      /* netcdf>=4.8.0 returns with filter_id==0 if no filters defined for variable;
-         earlier versions returned error status */
-      if (status == NC_NOERR && filter_id == 0) {
-        status = NC_EFILTER;
+      /* Query number of filters for the variable */
+      R_nc_check (nc_inq_var_filter_ids (ncid, varid, &nfilter, NULL));
+
+      /* Prepare R list items */
+      rfilter_id = PROTECT(allocVector(REALSXP, nfilter));
+      rfilter_params = PROTECT(allocVector(VECSXP, nfilter));
+      SET_VECTOR_ELT (result, 16, rfilter_id);
+      SET_VECTOR_ELT (result, 17, rfilter_params);
+      UNPROTECT(2);
+      dfiltid = REAL (rfilter_id);
+
+      /* Query filter ids, converting from unsigned int to R real */
+      if (nfilter > 0) {
+        ufiltid = (unsigned int *) R_alloc (nfilter, sizeof(unsigned int));
+        R_nc_check (nc_inq_var_filter_ids (ncid, varid, &nfilter, ufiltid));
+        for (ifilter=0; ifilter<nfilter; ifilter++) {
+          dfiltid[ifilter] = ufiltid[ifilter];
+        }
       }
-      if (status == NC_NOERR) {
-	SET_VECTOR_ELT (result, 16, ScalarInteger (filter_id));
-	rfilter_params = PROTECT(allocVector (INTSXP, filter_nparams));
-	SET_VECTOR_ELT (result, 17, rfilter_params);
-	UNPROTECT(1);
-	if (filter_nparams > 0) {
-	  R_nc_check (nc_inq_var_filter (ncid, varid, NULL, NULL,
-			(unsigned int *) INTEGER (rfilter_params)));
-	}
-#  ifdef NC_ENOFILTER
-      } else if (status == NC_EFILTER || status == NC_ENOFILTER ) {
-#  else
-      } else if (status == NC_EFILTER) {
-#  endif
-	SET_VECTOR_ELT (result, 16, ScalarInteger (NA_INTEGER));
-	SET_VECTOR_ELT (result, 17, ScalarInteger (NA_INTEGER));
-      } else {
-	error (nc_strerror (status));
+
+      /* Query filter parameters for each filter,
+         converting from unsigned int to R real.
+         Memory allocated by R_nc_c2r_init is freed automatically by R.
+       */
+      for (ifilter=0; ifilter<nfilter; ifilter++) {
+        R_nc_check (nc_inq_var_filter_info (ncid, varid, ufiltid[ifilter], &nfiltparm, NULL));
+        ufiltparm = NULL;
+        rfiltparm = PROTECT (R_nc_c2r_init (&filtio, (void **) &ufiltparm,
+          ncid, NC_UINT, 1, &nfiltparm, 0, 0, 0,
+          NULL, NULL, NULL, NULL, NULL));
+        SET_VECTOR_ELT (rfilter_params, ifilter, rfiltparm);
+        UNPROTECT(1);
+        R_nc_check (nc_inq_var_filter_info (ncid, varid, ufiltid[ifilter], &nfiltparm, ufiltparm));
+        R_nc_c2r(&filtio);
       }
+
     } else {
       /* netcdf>=4.7.4 returns NC_EINVAL for non-chunked variables */
-      SET_VECTOR_ELT (result, 16, ScalarInteger (NA_INTEGER));
-      SET_VECTOR_ELT (result, 17, ScalarInteger (NA_INTEGER));
+      SET_VECTOR_ELT (result, 16, allocVector(REALSXP, 0));
+      SET_VECTOR_ELT (result, 17, allocVector(VECSXP, 0));
     }
 #else
     SET_VECTOR_ELT (result, 16, R_NilValue);

--- a/src/variable.c
+++ b/src/variable.c
@@ -77,7 +77,7 @@ R_nc_def_var (SEXP nc, SEXP varname, SEXP type, SEXP dims,
 #endif
 #ifdef HAVE_NC_DEF_VAR_FILTER
   unsigned int *ufiltid, *ufiltparm;
-  size_t ifilter, nfilter;
+  size_t ifilter, nfilter, nfiltparm;
   SEXP rfiltparm;
 #endif
 

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -205,15 +205,10 @@ for (format in c("classic","offset64","data64","classic4","netcdf4")) {
     inq_filter <- list()
     inq_filter$filter_id <- c(2,1) # Shuffle, deflate
     inq_filter$filter_params <- list(numeric(0),c(9))
-    y <- try(var.def.nc(nc, "temp_filter", "NC_FLOAT", c("station", "time"),
+    var.def.nc(nc, "temp_filter", "NC_FLOAT", c("station", "time"),
                chunking=TRUE, filter_id=inq_filter$filter_id,
-               filter_params=inq_filter$filter_params), silent=TRUE)
-    has_filter <- !inherits(y, "try-error")
-    if (has_filter) {
-      varcnt <- varcnt+1
-    } else {
-      warning("NetCDF library may not support multi-filter interface")
-    }
+               filter_params=inq_filter$filter_params)
+    varcnt <- varcnt+1
   }
 
   for (numtype in numtypes) {
@@ -489,10 +484,8 @@ for (format in c("classic","offset64","data64","classic4","netcdf4")) {
       var.put.nc(nc, "stationid", mybig64)
       tally <- testfun(TRUE, TRUE, tally)
     }
-    if (has_filter) {
-      var.put.nc(nc, "temp_filter", mytemperature)
-      tally <- testfun(TRUE, TRUE, tally)
-    }
+    var.put.nc(nc, "temp_filter", mytemperature)
+    tally <- testfun(TRUE, TRUE, tally)
   }
 
   for (numtype in numtypes) {
@@ -592,14 +585,12 @@ for (format in c("classic","offset64","data64","classic4","netcdf4")) {
     }
 
     # Check multi-filter inquiry:
-    if (has_filter) {
-      cat("Check filter settings after writing temp_filter ...")
-      x <- var.inq.nc(nc, "temp_filter")
-      if (is.null(x$filter_id) && is.null(x$filter_params)) {
-        cat("Feature not available in this NetCDF library version.\n")
-      } else {
-        tally <- testfun(x[names(inq_filter)], inq_filter, tally)
-      }
+    cat("Check filter settings after writing temp_filter ...")
+    x <- var.inq.nc(nc, "temp_filter")
+    if (is.null(x$filter_id) && is.null(x$filter_params)) {
+      cat("Multi-filters not available in this NetCDF library version.\n")
+    } else {
+      tally <- testfun(x[names(inq_filter)], inq_filter, tally)
     }
   }
 

--- a/tools/convert.m4
+++ b/tools/convert.m4
@@ -57,6 +57,10 @@ dnl Insert warning into generated C code:
  *  Local macros, constants and variables
 \*=============================================================================*/
 
+/* Definition of missing value used by bit64 package */
+#define NA_INTEGER64 LLONG_MIN
+
+/* Maximum length of R character string */
 #define RNC_CHARSXP_MAXLEN 2147483647
 
 /* Conversion from 64-bit integers to double may round upwards,
@@ -2003,3 +2007,15 @@ R_NC_DIM_R2C(R_nc_dim_r2c_int, int, int)
 R_NC_DIM_R2C(R_nc_dim_r2c_size, size, size_t)
 
 
+/* Wrap R_nc_dim_r2c_size for scalar arguments
+ */
+size_t
+R_nc_sizearg (SEXP size)
+{
+  size_t *result;
+  if (xlength (size) < 1) {
+    error ("Size argument must contain at least one numeric value");
+  }
+  result = R_nc_dim_r2c_size (size, 1, 0);
+  return *result;
+}


### PR DESCRIPTION
Recent versions of NetCDF have added support for hdf5 filter plugins. The initial NetCDF filter interface supported only a single filter, but hdf5 allows more than one filter per variable, and support for multiple filters has been evolving over the NetCDF-4.7.x series. The multi-filter API seems to have stabilised in NetCDF-4.8.0.

This pull request updates RNetCDF to use the multi-filter API. This also fixes a bug in the RNetCDF tests when used with NetCDF-4.8.0, due to changes in the return status of NetCDF filter inquiry routines when no filters are defined for a variable.

Please note that this PR removes support for the NetCDF single-filter routines, because they are redundant and may be deprecated in future. If plugin filters must be used with NetCDF-4.7.x, please use RNetCDF_2.4-2.