### PR TITLE
Identify netcdf4-specific details in help files

### DIFF
--- a/man/00RNetCDF.Rd
+++ b/man/00RNetCDF.Rd
@@ -75,7 +75,7 @@ Datasets in NetCDF4 format support additional external types, including:
     \code{NC_STRING}     \tab variable length character strings. \cr
   }
 
-These types are called ``external'', because they correspond to the portable external representation for NetCDF data. When a program reads external NetCDF data into an internal variable, the data is converted, if necessary, into the specified internal type. Similarly, if you write internal data into a NetCDF variable, this may cause it to be converted to a different external type, if the external type for the NetCDF variable differs from the internal type. 
+These types are called dquote{external}, because they correspond to the portable external representation for NetCDF data. When a program reads external NetCDF data into an internal variable, the data is converted, if necessary, into the specified internal type. Similarly, if you write internal data into a NetCDF variable, this may cause it to be converted to a different external type, if the external type for the NetCDF variable differs from the internal type.
 
 In addition to the external types, NetCDF4 supports user-defined types. See \code{\link{type.def.nc}} for more explanation.
 }

--- a/man/att.copy.nc.Rd
+++ b/man/att.copy.nc.Rd
@@ -9,10 +9,10 @@
 \usage{att.copy.nc(ncfile.in, variable.in, attribute, ncfile.out, variable.out)}
 
 \arguments{
-  \item{ncfile.in}{Object of class "\code{NetCDF}" which points to the input NetCDF dataset from which the attribute will be copied (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{ncfile.in}{Object of class \code{NetCDF} which points to the input NetCDF dataset from which the attribute will be copied (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{variable.in}{ID or name of the variable in the input NetCDF dataset from which the attribute will be copied, or \code{"NC_GLOBAL"} for a global attribute.}
   \item{attribute}{Name or ID of the attribute in the input NetCDF dataset to be copied.}
-  \item{ncfile.out}{Object of class "\code{NetCDF}" which points to the output NetCDF dataset to which the attribute will be copied (as returned from \code{\link[RNetCDF]{open.nc}}). It is permissible for the input and output NetCDF object to be the same.}
+  \item{ncfile.out}{Object of class \code{NetCDF} which points to the output NetCDF dataset to which the attribute will be copied (as returned from \code{\link[RNetCDF]{open.nc}}). It is permissible for the input and output NetCDF object to be the same.}
   \item{variable.out}{ID or name of the variable in the output NetCDF dataset to which the attribute will be copied, or \code{"NC_GLOBAL"} to copy to a global attribute.}
 }
 

--- a/man/att.delete.nc.Rd
+++ b/man/att.delete.nc.Rd
@@ -9,7 +9,7 @@
 \usage{att.delete.nc(ncfile, variable, attribute)}
 
 \arguments{
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{variable}{ID or name of the attribute's variable, or \code{"NC_GLOBAL"} for a global attribute.}
   \item{attribute}{The name of the attribute to be deleted.}
 }

--- a/man/att.get.nc.Rd
+++ b/man/att.get.nc.Rd
@@ -9,7 +9,7 @@
 \usage{att.get.nc(ncfile, variable, attribute, rawchar=FALSE, fitnum=FALSE)}
 
 \arguments{
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{variable}{ID or name of the variable from which the attribute will be read, or \code{"NC_GLOBAL"} for a global attribute.}
   \item{attribute}{Attribute name or ID.}
   \item{rawchar}{This option only relates to NetCDF attributes of type \code{NC_CHAR}. When \code{rawchar} is \code{FALSE} (default), a NetCDF attribute of type \code{NC_CHAR} is converted to a \code{character} string in R. If \code{rawchar} is \code{TRUE}, the bytes of \code{NC_CHAR} data are read into an R \code{raw} vector.}

--- a/man/att.inq.nc.Rd
+++ b/man/att.inq.nc.Rd
@@ -11,7 +11,7 @@
 \usage{att.inq.nc(ncfile, variable, attribute)}
 
 \arguments{
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{variable}{Either the ID or the name of the attribute's variable or \code{"NC_GLOBAL"} for a global attribute.}
   \item{attribute}{Either the ID or the name of the attribute to be inquired.}
 }

--- a/man/att.put.nc.Rd
+++ b/man/att.put.nc.Rd
@@ -9,14 +9,14 @@
 \usage{att.put.nc(ncfile, variable, name, type, value)}
 
 \arguments{
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{variable}{ID or name of the variable to which the attribute will be assigned or \code{"NC_GLOBAL"} for a global attribute.}
-  \item{name}{Attribute name. Must begin with an alphabetic character, followed by zero or more alphanumeric characters including the underscore ("\code{_}"). Case is significant. Attribute name conventions are assumed by some NetCDF generic applications, e.g., \code{units} as the name for a string attribute that gives the units for a NetCDF variable.}
+  \item{name}{Attribute name. Must begin with an alphabetic character, followed by zero or more alphanumeric characters including the underscore (\code{"_"}). Case is significant. Attribute name conventions are assumed by some NetCDF generic applications, e.g., \code{units} as the name for a string attribute that gives the units for a NetCDF variable.}
   \item{type}{External NetCDF data type as one of the following labels: \code{NC_BYTE}, \code{NC_UBYTE}, \code{NC_CHAR}, \code{NC_SHORT}, \code{NC_USHORT}, \code{NC_INT}, \code{NC_UINT}, \code{NC_INT64}, \code{NC_UINT64}, \code{NC_FLOAT}, \code{NC_DOUBLE}, \code{NC_STRING}, or a user-defined type name.}
   \item{value}{Attribute value. This can be either a single numeric value or a vector of numeric values, or alternatively a character string.}
 }
 
-\details{Names commencing with underscore ("\code{_}") are reserved for use by the NetCDF library. Most generic applications that process NetCDF datasets assume standard attribute conventions and it is strongly recommended that these be followed unless there are good reasons for not doing so.
+\details{Names commencing with underscore (\code{"_"}) are reserved for use by the NetCDF library. Most generic applications that process NetCDF datasets assume standard attribute conventions and it is strongly recommended that these be followed unless there are good reasons for not doing so.
 
 Text represented by R type \code{character} can be written to NetCDF types \code{NC_CHAR} and \code{NC_STRING}, and R type \code{raw} can be written to NetCDF type \code{NC_CHAR}.
 

--- a/man/att.rename.nc.Rd
+++ b/man/att.rename.nc.Rd
@@ -9,7 +9,7 @@
 \usage{att.rename.nc(ncfile, variable, attribute, newname)}
 
 \arguments{
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{variable}{ID or name of the attribute's variable, or \code{"NC_GLOBAL"} for a global attribute.}
   \item{attribute}{The current attribute name or ID.}
   \item{newname}{The new name to be assigned to the specified attribute.}

--- a/man/close.nc.Rd
+++ b/man/close.nc.Rd
@@ -9,7 +9,7 @@
 \usage{close.nc(con, ...)}
 
 \arguments{
-  \item{con}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{con}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{...}{Arguments passed to or from other methods (not used).}
 }
 

--- a/man/create.nc.Rd
+++ b/man/create.nc.Rd
@@ -15,25 +15,25 @@
   \item{clobber}{The creation mode. If \code{TRUE} (default), any existing dataset with the same filename will be overwritten. Otherwise set to \code{FALSE}.}
   \item{share}{The buffer scheme. If \code{FALSE} (default), dataset access is buffered and cached for performance. However, if one or more processes may be reading while another process is writing the dataset, set to \code{TRUE}.}
   \item{prefill}{The prefill mode. If \code{TRUE} (default), newly defined variables are initialised with fill values when they are first accessed. This allows unwritten array elements to be detected when reading, but it also implies duplicate writes if all elements are subsequently written with user-specified data. Enhanced write performance can be obtained by setting \code{prefill=FALSE}.}
-  \item{format}{The file format. One of "classic", "offset64", "data64", "netcdf4" or "classic4". See below for details.}
-  \item{large}{(Deprecated) \code{large=TRUE} sets the file format to "offset64" when \code{format="classic"}.}
+  \item{format}{The file format. One of \code{"classic"}, \code{"offset64"}, \code{"data64"}, \code{"netcdf4"} or \code{"classic4"}. See below for details.}
+  \item{large}{(Deprecated) \code{large=TRUE} sets the file format to \code{"offset64"} when \code{format="classic"}.}
   \item{diskless}{When \code{diskless=TRUE}, the file is created in memory without writing to disk. This allows netcdf datasets to be used as fast, temporary files. When the file is closed, the contents are lost unless \code{persist=TRUE}.}
   \item{persist}{When \code{persist=TRUE}, a file created with \code{diskless=TRUE} is flushed to disk when closed. In some cases, this may be faster than manipulating files directly on disk.}
   \item{mpi_comm}{Fortran handle of MPI communicator for parallel I/O. The default of \code{NULL} implies serial I/O. Valid Fortran handles may be obtained from your chosen MPI package for R - for example \link[pbdMPI]{comm.c2f}.}
   \item{mpi_info}{Fortran handle of MPI Info object for parallel I/O. The default value \code{NULL} implies serial I/O. Valid Fortran handles may be obtained from your chosen MPI package for R - for example \link[pbdMPI]{info.c2f}.}
 }
 
-\value{Object of class "\code{NetCDF}" which points to the NetCDF dataset, returned invisibly.}
+\value{Object of class \code{NetCDF} which points to the NetCDF dataset, returned invisibly.}
 
-\details{This function creates a new NetCDF dataset, returning an object of class "\code{NetCDF}" that can be used in R.
+\details{This function creates a new NetCDF dataset, returning an object of class \code{NetCDF} that can be used in R.
 
 The file format is specified by the \code{format} argument, which may take the following values:
 \describe{
-  \item{"classic"}{(default) Original netcdf file format, still widely used and recommended for maximum portability of datasets. Uses a signed 32-bit offset in its internal structures, so files larger than 2GB can only be created under limited conditions.}
-  \item{"offset64"}{64-bit offset extension of original format, introduced by netcdf-3.6. Allows larger files and variables than "classic" format, but there remain some restrictions on files larger than 2GB.}
-  \item{"data64"}{Extension of "classic" format to support large files (i.e. over 2GB) and large variables (over 2B array elements). This format was introduced in netcdf-4.4.0.}
-  \item{"netcdf4"}{Netcdf in an HDF5 container, introduced by netcdf-4.0. Allows dataset sizes up to filesystem limits, and extends the feature set of the older formats.}
-  \item{"classic4"}{Same file format as "netcdf4", but this option ensures that only classic netcdf data structures are stored in the file for compatibility with older software (when linked with the netcdf4 library).}
+  \item{\code{"classic"}}{(default) Original netcdf file format, still widely used and recommended for maximum portability of datasets. Uses a signed 32-bit offset in its internal structures, so files larger than 2GB can only be created under limited conditions.}
+  \item{\code{"offset64"}}{64-bit offset extension of original format, introduced by netcdf-3.6. Allows larger files and variables than \code{"classic"} format, but there remain some restrictions on files larger than 2GB.}
+  \item{\code{"data64"}}{Extension of \code{"classic"} format to support large files (i.e. over 2GB) and large variables (over 2B array elements). This format was introduced in netcdf-4.4.0.}
+  \item{\code{"netcdf4"}}{Netcdf in an HDF5 container, introduced by netcdf-4.0. Allows dataset sizes up to filesystem limits, and extends the feature set of the older formats.}
+  \item{\code{"classic4"}}{Same file format as \code{"netcdf4"}, but this option ensures that only classic netcdf data structures are stored in the file for compatibility with older software (when linked with the netcdf4 library).}
 }
 }
 

--- a/man/dim.def.nc.Rd
+++ b/man/dim.def.nc.Rd
@@ -9,8 +9,8 @@
 \usage{dim.def.nc(ncfile, dimname, dimlength=1, unlim=FALSE)}
 
 \arguments{
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
-  \item{dimname}{Dimension name. Must begin with an alphabetic character, followed by zero or more alphanumeric characters including the underscore ("\code{_}"). Case is significant.}
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{dimname}{Dimension name. Must begin with an alphabetic character, followed by zero or more alphanumeric characters including the underscore (\code{"_"}). Case is significant.}
   \item{dimlength}{Length of dimension, that is, number of values for this dimension as an index to variables that use it. This must be a positive integer. If an unlimited dimension is created (\code{unlim=TRUE}), the value of \code{length} is not used.}
   \item{unlim}{Set to \code{TRUE} if an unlimited dimension should be created, otherwise to \code{FALSE}.}
 }

--- a/man/dim.inq.nc.Rd
+++ b/man/dim.inq.nc.Rd
@@ -9,7 +9,7 @@
 \usage{dim.inq.nc(ncfile, dimension)}
 
 \arguments{
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{dimension}{Either the ID or the name of the dimension to be inquired.}
 }
 

--- a/man/dim.rename.nc.Rd
+++ b/man/dim.rename.nc.Rd
@@ -9,7 +9,7 @@
 \usage{dim.rename.nc(ncfile, dimension, newname)}
 
 \arguments{
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{dimension}{Either the ID or the name of the dimension to be renamed.}
   \item{newname}{The new dimension name.}
 }

--- a/man/file.inq.nc.Rd
+++ b/man/file.inq.nc.Rd
@@ -9,7 +9,7 @@
 \usage{file.inq.nc(ncfile)}
 
 \arguments{
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
 }
 
 \value{
@@ -18,7 +18,7 @@
   \item{nvars}{Number of variables defined for this NetCDF dataset.}
   \item{ngatts}{Number of global attributes for this NetCDF dataset.}
   \item{unlimdimid}{ID of the unlimited dimension, if there is one for this NetCDF dataset. Otherwise \code{NA} will be returned.} 
-  \item{format}{Format of file, typically "classic", "offset64", "data64", "classic4" or "netcdf4".}
+  \item{format}{Format of file, typically \code{"classic"}, \code{"offset64"}, \code{"data64"}, \code{"classic4"} or \code{"netcdf4"}.}
   \item{libvers}{Version string of the NetCDF library in the current R session.}
 }
 

--- a/man/grp.def.nc.Rd
+++ b/man/grp.def.nc.Rd
@@ -9,15 +9,15 @@
 \usage{grp.def.nc(ncid, grpname)}
 
 \arguments{
-  \item{ncid}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}) or parent group (as returned by this function).}
-  \item{grpname}{Group name. Must begin with an alphabetic character, followed by zero or more alphanumeric characters including the underscore ("\code{_}"). Case is significant.}
+  \item{ncid}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}) or parent group (as returned by this function).}
+  \item{grpname}{Group name. Must begin with an alphabetic character, followed by zero or more alphanumeric characters including the underscore (\code{"_"}). Case is significant.}
 }
 
-\value{Object of class "\code{NetCDF}" which points to the NetCDF group, returned invisibly.}
+\value{Object of class \code{NetCDF} which points to the NetCDF group, returned invisibly.}
 
-\details{This function may only be used with datasets in "netcdf4" format. It creates a new NetCDF group, which may be used as a container for other NetCDF objects, including groups, dimensions, variables and attributes.
+\details{This function may only be used with datasets in \code{netcdf4} format. It creates a new NetCDF group, which may be used as a container for other NetCDF objects, including groups, dimensions, variables and attributes.
 
-Most NetCDF object types, including groups, variables and "global" attributes, are visible only in the group where they are defined. However, dimensions are visible in their groups and all child groups.}
+Most NetCDF object types, including groups, variables and global attributes, are visible only in the group where they are defined. However, dimensions are visible in their groups and all child groups.}
 
 \references{\url{https://www.unidata.ucar.edu/software/netcdf/}}
 

--- a/man/grp.def.nc.Rd
+++ b/man/grp.def.nc.Rd
@@ -15,7 +15,7 @@
 
 \value{Object of class "\code{NetCDF}" which points to the NetCDF group, returned invisibly.}
 
-\details{This function may only be used with files in netcdf4 format. It creates a new NetCDF group, which may be used as a container for other NetCDF objects, including groups, dimensions, variables and attributes.
+\details{This function may only be used with datasets in "netcdf4" format. It creates a new NetCDF group, which may be used as a container for other NetCDF objects, including groups, dimensions, variables and attributes.
 
 Most NetCDF object types, including groups, variables and "global" attributes, are visible only in the group where they are defined. However, dimensions are visible in their groups and all child groups.}
 

--- a/man/grp.inq.nc.Rd
+++ b/man/grp.inq.nc.Rd
@@ -9,8 +9,8 @@
 \usage{grp.inq.nc(ncid,grpname=NULL,ancestors=TRUE)}
 
 \arguments{
-  \item{ncid}{Object of class "\code{NetCDF}" which points to a NetCDF group (from \code{\link[RNetCDF]{grp.def.nc}}) or dataset (from \code{\link[RNetCDF]{open.nc}}).}
-  \item{grpname}{By default, the inquiry relates to the group represented by \code{ncid}. If \code{grpname} is a character string, a group with this name is examined instead. A hierarchical search is performed if \code{grpname} contains "/", otherwise only the immediate group of \code{ncid} is searched for a matching group name.}
+  \item{ncid}{Object of class \code{NetCDF} which points to a NetCDF group (from \code{\link[RNetCDF]{grp.def.nc}}) or dataset (from \code{\link[RNetCDF]{open.nc}}).}
+  \item{grpname}{By default, the inquiry relates to the group represented by \code{ncid}. If \code{grpname} is a character string, a group with this name is examined instead. A hierarchical search is performed if \code{grpname} contains \code{"/"}, otherwise only the immediate group of \code{ncid} is searched for a matching group name.}
  \item{ancestors}{If \code{TRUE}, dimensions and names of ancestor groups are examined. Otherwise, only dimensions and names defined in the current group are reported.}
 }
 
@@ -20,7 +20,7 @@
   \item{parent}{Object of class \code{NetCDF} representing the parent group, or \code{NULL} for the root group.}
   \item{grps}{List of objects of class \code{NetCDF} representing the groups in the group.}
   \item{name}{Name of the NetCDF group.}
-  \item{fullname}{Full name of the NetCDF group, with ancestors listed in order from the root group of the dataset and separated by "/". Omitted if \code{ancestors} is \code{FALSE}.} 
+  \item{fullname}{Full name of the NetCDF group, with ancestors listed in order from the root group of the dataset and separated by \code{"/"}. Omitted if \code{ancestors} is \code{FALSE}.} 
   \item{dimids}{Vector of dimension identifiers. If \code{ancestors} is \code{TRUE} (default), all visible dimensions in the group and its ancestors are reported, otherwise only dimensions defined in the group of \code{ncid} are shown.}
   \item{unlimids}{Vector of identifiers for unlimited dimensions. If \code{ancestors} is \code{TRUE} (default), all unlimited dimensions in the group and its ancestors are reported, otherwise only unlimited dimensions defined in the group of \code{ncid} are shown.}
   \item{varids}{Vector of identifiers for variables in the group.}

--- a/man/grp.rename.nc.Rd
+++ b/man/grp.rename.nc.Rd
@@ -14,7 +14,7 @@
   \item{oldname}{By default, the rename applies to the group represented by \code{ncid}. If \code{oldname} is a character string, a group with this name is renamed instead. A hierarchical search is performed if \code{oldname} contains "/", otherwise only the immediate group of \code{ncid} is searched for a matching group name.}
 }
 
-\details{This function renames an existing group in a NetCDF dataset or group that is open for writing. A group cannot be renamed to have the same name as another group, type or variable in the parent group.}
+\details{This function renames an existing group in a dataset of "netcdf4" format that is open for writing. A group cannot be renamed to have the same name as another group, type or variable in the parent group.}
 
 \references{\url{https://www.unidata.ucar.edu/software/netcdf/}}
 
@@ -27,7 +27,7 @@ nc <- create.nc(file1, format="netcdf4")
 
 grp <- grp.def.nc(nc, "oldgroup")
 
-##  Rename the group (operation not support by early versions of the netcdf4 library)
+##  Rename the group (operation not supported by early versions of the netcdf4 library)
 try(grp.rename.nc(grp, "newgroup"))
 
 close.nc(nc)

--- a/man/grp.rename.nc.Rd
+++ b/man/grp.rename.nc.Rd
@@ -9,12 +9,12 @@
 \usage{grp.rename.nc(ncid, newname, oldname=NULL)}
 
 \arguments{
-  \item{ncid}{Object of class "\code{NetCDF}" which points to a NetCDF group (from \code{\link[RNetCDF]{grp.def.nc}}) or dataset (from \code{\link[RNetCDF]{open.nc}}).}
+  \item{ncid}{Object of class \code{NetCDF} which points to a NetCDF group (from \code{\link[RNetCDF]{grp.def.nc}}) or dataset (from \code{\link[RNetCDF]{open.nc}}).}
   \item{newname}{The new group name.}
-  \item{oldname}{By default, the rename applies to the group represented by \code{ncid}. If \code{oldname} is a character string, a group with this name is renamed instead. A hierarchical search is performed if \code{oldname} contains "/", otherwise only the immediate group of \code{ncid} is searched for a matching group name.}
+  \item{oldname}{By default, the rename applies to the group represented by \code{ncid}. If \code{oldname} is a character string, a group with this name is renamed instead. A hierarchical search is performed if \code{oldname} contains \code{"/"}, otherwise only the immediate group of \code{ncid} is searched for a matching group name.}
 }
 
-\details{This function renames an existing group in a dataset of "netcdf4" format that is open for writing. A group cannot be renamed to have the same name as another group, type or variable in the parent group.}
+\details{This function renames an existing group in a dataset of \code{"netcdf4"} format that is open for writing. A group cannot be renamed to have the same name as another group, type or variable in the parent group.}
 
 \references{\url{https://www.unidata.ucar.edu/software/netcdf/}}
 

--- a/man/open.nc.Rd
+++ b/man/open.nc.Rd
@@ -23,7 +23,7 @@
   \item{...}{Arguments passed to or from other methods (not used).}
 }
 
-\value{Object of class "\code{NetCDF}" which points to the NetCDF dataset, returned invisibly.}
+\value{Object of class \code{NetCDF} which points to the NetCDF dataset, returned invisibly.}
 
 \details{This function opens an existing NetCDF dataset for access. By default, the dataset is opened read-only. If \code{write=TRUE}, then the dataset can be changed. This includes appending or changing data, adding dimensions, variables, and attributes.}
 

--- a/man/print.nc.Rd
+++ b/man/print.nc.Rd
@@ -9,7 +9,7 @@
 \usage{print.nc(x, ...)}
 
 \arguments{
-  \item{x}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{x}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{...}{Arguments passed to or from other methods (not used).}
 }
 

--- a/man/read.nc.Rd
+++ b/man/read.nc.Rd
@@ -11,7 +11,7 @@
 }
 
 \arguments{
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{recursive}{Descend recursively into any groups in the dataset if \code{TRUE}.}
   \item{...}{Optional arguments passed to \code{var.get.nc}.}
 }

--- a/man/sync.nc.Rd
+++ b/man/sync.nc.Rd
@@ -9,7 +9,7 @@
 \usage{sync.nc(ncfile)}
 
 \arguments{
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
 }
 
 \details{This function offers a way to synchronize the disk copy of a NetCDF dataset with in-memory buffers. There are two reasons one might want to synchronize after writes: To minimize data loss in case of abnormal termination, or to make data available to other processes for reading immediately after it is written.}

--- a/man/type.def.nc.Rd
+++ b/man/type.def.nc.Rd
@@ -12,31 +12,31 @@ type.def.nc(ncfile, typename, class, size=NULL, basetype=NULL,
 }
 
 \arguments{
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
-  \item{typename}{Name to identify the new data type. Must begin with an alphabetic character, followed by zero or more alphanumeric characters including the underscore ("\code{_}"). Case is significant.}
-  \item{class}{One of the keywords "compound", "enum", "opaque" or "vlen".}
-  \item{size}{("opaque") Size in bytes of a single item of the opaque type.}
-  \item{basetype}{("enum" or "vlen") Base type, given as the name or identifier of an existing NetCDF type. Only built-in integer types (e.g. "NC_INT") are allowed for \code{class} "enum".}
-  \item{names}{("compound" or "enum") Name of each field or member (character vector).}
-  \item{values}{("enum") Numeric value of each member (numeric vector).}
-  \item{subtypes}{("compound") NetCDF type of each field, given by name (character vector) or identifier (numeric vector).}
-  \item{dimsizes}{("compound") Array dimensions of each field, specified as a list of numeric vectors. Dimensions are given in R order (leftmost index varies fastest; opposite to CDL conventions). If a list item is \code{NULL}, the corresponding field is a scalar.}
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{typename}{Name to identify the new data type. Must begin with an alphabetic character, followed by zero or more alphanumeric characters including the underscore (\code{"_"}). Case is significant.}
+  \item{class}{One of the keywords \code{"compound"}, \code{"enum"}, \code{"opaque"} or \code{"vlen"}.}
+  \item{size}{(\code{"opaque"}) Size in bytes of a single item of the opaque type.}
+  \item{basetype}{(\code{"enum"} or \code{"vlen"}) Base type, given as the name or identifier of an existing NetCDF type. Only built-in integer types (e.g. \code{"NC_INT"}) are allowed for \code{class="enum"}.}
+  \item{names}{(\code{"compound"} or \code{"enum"}) Name of each field or member (character vector).}
+  \item{values}{(\code{"enum"}) Numeric value of each member (numeric vector).}
+  \item{subtypes}{(\code{"compound"}) NetCDF type of each field, given by name (character vector) or identifier (numeric vector).}
+  \item{dimsizes}{(\code{"compound"}) Array dimensions of each field, specified as a list of numeric vectors. Dimensions are given in R order (leftmost index varies fastest; opposite to CDL conventions). If a list item is \code{NULL}, the corresponding field is a scalar.}
 }
 
 \value{NetCDF type identifier, returned invisibly.}
 
-\details{User-defined types are supported by files in "netcdf4" format. This function creates a new NetCDF data type, which can be used in definitions of NetCDF variables and attributes.
+\details{User-defined types are supported by files in \code{"netcdf4"} format. This function creates a new NetCDF data type, which can be used in definitions of NetCDF variables and attributes.
 
 Several varieties of data type are supported, as specified by argument \code{class}:
 
   \tabular{ll}{
-    "compound" \tab Combines atomic and user-defined types into C-like structs. \cr
-    "enum"     \tab Set of named integer values, similar to an R \code{factor}. \cr
-    "opaque"   \tab Blobs of arbitrary data with a given size. \cr
-    "vlen"     \tab Variable length vectors of a given base type. \cr
+    \code{"compound"} \tab Combines atomic and user-defined types into C-like structs. \cr
+    \code{"enum"}     \tab Set of named integer values, similar to an R \code{factor}. \cr
+    \code{"opaque"}   \tab Blobs of arbitrary data with a given size. \cr
+    \code{"vlen"}     \tab Variable length vectors of a given base type. \cr
   }
 
-\code{type.def.nc} may be repeated to insert additional members of an "enum" type or fields of a "compound" type. However, the size of a "compound" type is calculated from the fields specified when it is first defined, and later insertion of fields will only succeed if there is sufficient free space after the last field. Existing fields/members cannot be modified, and types cannot be removed from a dataset.
+\code{type.def.nc} may be repeated to insert additional members of an \code{"enum"} type or fields of a \code{"compound"} type. However, the size of a \code{"compound"} type is calculated from the fields specified when it is first defined, and later insertion of fields will only succeed if there is sufficient free space after the last field. Existing fields/members cannot be modified, and types cannot be removed from a dataset.
 }
 
 \references{\url{https://www.unidata.ucar.edu/software/netcdf/}}

--- a/man/type.inq.nc.Rd
+++ b/man/type.inq.nc.Rd
@@ -11,7 +11,7 @@
 \arguments{
   \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset or group.}
   \item{type}{ID or name of a NetCDF data type.}
-  \item{fields}{Read members of enum types or fields of compound types (default \code{TRUE})}.
+  \item{fields}{Read members of enum types or fields of compound types (default \code{TRUE}).}
 }
 
 \value{

--- a/man/type.inq.nc.Rd
+++ b/man/type.inq.nc.Rd
@@ -9,7 +9,7 @@
 \usage{type.inq.nc(ncfile, type, fields=TRUE)}
 
 \arguments{
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset or group.}
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset or group.}
   \item{type}{ID or name of a NetCDF data type.}
   \item{fields}{Read members of enum types or fields of compound types (default \code{TRUE}).}
 }
@@ -18,15 +18,17 @@
   A list containing the following components:
   \item{id}{Type ID.}
   \item{name}{Type name.}
-  \item{class}{One of the keywords "builtin", "compound", "enum", "opaque" or "vlen".}
-  \item{size}{Size in bytes of a single item of the type (or a single element of a "vlen").}
-  \item{basetype}{("enum" or "vlen") Name of the NetCDF type of each element.}
+  \item{class}{One of the keywords \code{"builtin"}, \code{"compound"}, \code{"enum"}, \code{"opaque"} or \code{"vlen"}.}
+  \item{size}{Size in bytes of a single item of the type (or a single element of a \code{"vlen"}).}
+  \item{basetype}{(\code{"enum"} or \code{"vlen"}) Name of the NetCDF type of each element.}
+
 
   If \code{fields=TRUE}, the return list includes details about members of enum types or fields of compound types:
-  \item{value}{("enum" only) Named vector with numeric values of all members.}
-  \item{offset}{("compound" only) Named vector with the offset of each field in bytes from the beginning of the compound type.}
-  \item{subtype}{("compound" only) Named vector with the NetCDF type name of each field.}
-  \item{dimsizes}{("compound" only) Named list with array dimensions of each field. Dimension lengths are reported in R order (leftmost index varies fastest; opposite to CDL conventions). A \code{NULL} length indicates a scalar.}
+
+  \item{value}{(\code{"enum"} only) Named vector with numeric values of all members.}
+  \item{offset}{(\code{"compound"} only) Named vector with the offset of each field in bytes from the beginning of the compound type.}
+  \item{subtype}{(\code{"compound"} only) Named vector with the NetCDF type name of each field.}
+  \item{dimsizes}{(\code{"compound"} only) Named list with array dimensions of each field. Dimension lengths are reported in R order (leftmost index varies fastest; opposite to CDL conventions). A \code{NULL} length indicates a scalar.}
 }
 
 \details{This function obtains information about a NetCDF data type, which could be builtin or user-defined. The items in the return list depend on the class of the NetCDF type.}

--- a/man/utcal.nc.Rd
+++ b/man/utcal.nc.Rd
@@ -9,16 +9,16 @@
 \usage{utcal.nc(unitstring, value, type="n")}
 
 \arguments{
-  \item{unitstring}{A temporal unit with an origin (e.g., ``days since 1900-01-01'').}
+  \item{unitstring}{A temporal unit with an origin (e.g., \code{"days since 1900-01-01"}).}
   \item{value}{An amount (quantity) of the given temporal unit.}
-  \item{type}{Character string which determines the output type. Can be \code{n} for numeric, \code{s} for string or \code{c} for POSIXct output.}
+  \item{type}{Character string which determines the output type. Can be \code{"n"} for numeric, \code{"s"} for string or \code{"c"} for POSIXct output.}
 }
 
 \value{If the output type is set to numeric, result is a matrix containing the corresponding date(s) and time(s), with the following columns: year, month, day, hour, minute, second. If the output type is string, result is a vector of strings in the form \code{"YYYY-MM-DD hh:mm:ss"}. Otherwise result is a vector of POSIXct values.}
 
 \details{Converts the amount, \code{value}, of the temporal unit, \code{unitstring}, into a UTC-referenced date and time.
 
-Functions \code{utcal.nc} and \code{utinvcal.nc} provide a convenient way to convert time values between the forms used by NetCDF variables and R functions. Most R functions require times to be expressed as seconds since the beginning of 1970 in the UTC time zone, typically using objects of class \code{POSIXct} or \code{POSIXlt}. NetCDF files store times in numeric variables with a wide variety of units. The units and calendar are stored in attributes of the time variable, as described by the CF Conventions. Units are expressed as a string, in the form of a time unit since a fixed date-time (e.g. ``hours since 2000-01-01 00:00:00 +00:00'', or more simply ``hours since 2000-01-01'').
+Functions \code{utcal.nc} and \code{utinvcal.nc} provide a convenient way to convert time values between the forms used by NetCDF variables and R functions. Most R functions require times to be expressed as seconds since the beginning of 1970 in the UTC time zone, typically using objects of class \code{POSIXct} or \code{POSIXlt}. NetCDF files store times in numeric variables with a wide variety of units. The units and calendar are stored in attributes of the time variable, as described by the CF Conventions. Units are expressed as a string, in the form of a time unit since a fixed date-time (e.g. \code{"hours since 2000-01-01 00:00:00 +00:00"}, or more simply \code{"hours since 2000-01-01"}).
 
 The conversions of times between units are performed by the UDUNITS library using a mixed Gregorian/Julian calendar system. Dates prior to 1582-10-15 are assumed to use the Julian calendar, which was introduced by Julius Caesar in 46 BCE and is based on a year that is exactly 365.25 days long. Dates on and after 1582-10-15 are assumed to use the Gregorian calendar, which was introduced on that date and is based on a year that is exactly 365.2425 days long. (A year is actually approximately 365.242198781 days long.) Seemingly strange behavior of the UDUNITS package can result if a user-given time interval includes the changeover date.
 

--- a/man/utinvcal.nc.Rd
+++ b/man/utinvcal.nc.Rd
@@ -9,7 +9,7 @@
 \usage{utinvcal.nc(unitstring, value)}
 
 \arguments{
-  \item{unitstring}{A temporal unit with an origin (e.g., ``days since 1900-01-01'').}
+  \item{unitstring}{A temporal unit with an origin (e.g., \code{"days since 1900-01-01"}).}
   \item{value}{Dates to convert as a numeric vector or array, or a vector of strings or POSIXct values.}
 }
 

--- a/man/var.def.nc.Rd
+++ b/man/var.def.nc.Rd
@@ -12,19 +12,20 @@
                   filter_id=integer(0), filter_params=list())}
 
 \arguments{
+  Arguments marked for "netcdf4" are optional for datasets in that format and ignored for other formats.
   \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{varname}{Variable name. Must begin with an alphabetic character, followed by zero or more alphanumeric characters including the underscore ("\code{_}"). Case is significant.}
   \item{vartype}{External NetCDF data type as one of the following labels: \code{NC_BYTE}, \code{NC_UBYTE}, \code{NC_CHAR}, \code{NC_SHORT}, \code{NC_USHORT}, \code{NC_INT}, \code{NC_UINT}, \code{NC_INT64}, \code{NC_UINT64}, \code{NC_FLOAT}, \code{NC_DOUBLE}, \code{NC_STRING}, or a user-defined type name.}
   \item{dimensions}{Vector of \code{ndims} dimension IDs or their names corresponding to the variable dimensions or \code{NA} if a scalar variable should be created. If the ID (or name) of the unlimited dimension is included, it must be last.}
-  The following arguments are optional for datasets in "netcdf4" format (and ignored for other formats):
-  \item{chunking}{\code{TRUE} selects chunking, \code{FALSE} implies contiguous storage, \code{NA} allows the NetCDF library to choose a storage layout. Ignored for scalar variables.}
-  \item{chunksizes}{Chunk size expressed as the number of elements along each dimension, in the same order as \code{dimensions}. If \code{NULL}, the NetCDF library uses a default chunking strategy, which is intended to give reasonable performance in typical applications. Ignored unless \code{chunking} is \code{TRUE}.}
-  \item{deflate}{Integer indicating level of compression, from 0 (minimum) to 9 (maximum), or \code{NA} for no compression. The compression only works in netcdf4 files.}
-  \item{shuffle}{\code{TRUE} to enable byte shuffling, which may improve compression with \code{deflate}.}
-  \item{big_endian}{Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for native endianness of the platform.}
-  \item{fletcher32}{\code{TRUE} to enable the fletcher32 checksum.}
-  \item{filter_id}{Vector of filter IDs to associate with the variable (empty vector denotes no filters). For information about the available filters, please see the NetCDF documentation. Ignored if the installed NetCDF library does not support the multi-filter interface.}
-  \item{filter_params}{List with one element for each \code{filter_id}. Each list member is a vector of \code{numeric} parameters (which are converted to unsigned integers). The meaning of the parameters depends on the filter implementation, and RNetCDF is unable to perform any validation. Ignored if the installed NetCDF library does not support the multi-filter interface.}
+
+  \item{chunking}{(netcdf4) \code{TRUE} selects chunking, \code{FALSE} implies contiguous storage, \code{NA} allows the NetCDF library to choose a storage layout. Ignored for scalar variables.}
+  \item{chunksizes}{(netcdf4) Chunk size expressed as the number of elements along each dimension, in the same order as \code{dimensions}. If \code{NULL}, the NetCDF library uses a default chunking strategy, which is intended to give reasonable performance in typical applications. Ignored unless \code{chunking} is \code{TRUE}.}
+  \item{deflate}{(netcdf4) Integer indicating level of compression, from 0 (minimum) to 9 (maximum), or \code{NA} for no compression.}
+  \item{shuffle}{(netcdf4) \code{TRUE} to enable byte shuffling, which may improve compression with \code{deflate}.}
+  \item{big_endian}{(netcdf4) Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for native endianness of the platform.}
+  \item{fletcher32}{(netcdf4) \code{TRUE} to enable the fletcher32 checksum.}
+  \item{filter_id}{(netcdf4) Vector of filter IDs to associate with the variable (empty vector denotes no filters). For information about the available filters, please see the NetCDF documentation. Ignored if the installed NetCDF library does not support the multi-filter interface.}
+  \item{filter_params}{(netcdf4) List with one element for each \code{filter_id}. Each list member is a vector of \code{numeric} parameters (which are converted to unsigned integers). The meaning of the parameters depends on the filter implementation, and RNetCDF is unable to perform any validation. Ignored if the installed NetCDF library does not support the multi-filter interface.}
 }
 
 \value{NetCDF variable identifier, returned invisibly.}

--- a/man/var.def.nc.Rd
+++ b/man/var.def.nc.Rd
@@ -12,20 +12,20 @@
                   filter_id=integer(0), filter_params=list())}
 
 \arguments{
-  Arguments marked for "netcdf4" are optional for datasets in that format and ignored for other formats.
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
-  \item{varname}{Variable name. Must begin with an alphabetic character, followed by zero or more alphanumeric characters including the underscore ("\code{_}"). Case is significant.}
+  Arguments marked \code{"netcdf4"} are optional for datasets in that format and ignored for other formats.
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{varname}{Variable name. Must begin with an alphabetic character, followed by zero or more alphanumeric characters including the underscore (\code{"_"}). Case is significant.}
   \item{vartype}{External NetCDF data type as one of the following labels: \code{NC_BYTE}, \code{NC_UBYTE}, \code{NC_CHAR}, \code{NC_SHORT}, \code{NC_USHORT}, \code{NC_INT}, \code{NC_UINT}, \code{NC_INT64}, \code{NC_UINT64}, \code{NC_FLOAT}, \code{NC_DOUBLE}, \code{NC_STRING}, or a user-defined type name.}
   \item{dimensions}{Vector of \code{ndims} dimension IDs or their names corresponding to the variable dimensions or \code{NA} if a scalar variable should be created. If the ID (or name) of the unlimited dimension is included, it must be last.}
 
-  \item{chunking}{(netcdf4) \code{TRUE} selects chunking, \code{FALSE} implies contiguous storage, \code{NA} allows the NetCDF library to choose a storage layout. Ignored for scalar variables.}
-  \item{chunksizes}{(netcdf4) Chunk size expressed as the number of elements along each dimension, in the same order as \code{dimensions}. If \code{NULL}, the NetCDF library uses a default chunking strategy, which is intended to give reasonable performance in typical applications. Ignored unless \code{chunking} is \code{TRUE}.}
-  \item{deflate}{(netcdf4) Integer indicating level of compression, from 0 (minimum) to 9 (maximum), or \code{NA} for no compression.}
-  \item{shuffle}{(netcdf4) \code{TRUE} to enable byte shuffling, which may improve compression with \code{deflate}.}
-  \item{big_endian}{(netcdf4) Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for native endianness of the platform.}
-  \item{fletcher32}{(netcdf4) \code{TRUE} to enable the fletcher32 checksum.}
-  \item{filter_id}{(netcdf4) Vector of filter IDs to associate with the variable (empty vector denotes no filters). For information about the available filters, please see the NetCDF documentation. Ignored if the installed NetCDF library does not support the multi-filter interface.}
-  \item{filter_params}{(netcdf4) List with one element for each \code{filter_id}. Each list member is a vector of \code{numeric} parameters (which are converted to unsigned integers). The meaning of the parameters depends on the filter implementation, and RNetCDF is unable to perform any validation. Ignored if the installed NetCDF library does not support the multi-filter interface.}
+  \item{chunking}{(\code{"netcdf4"}) \code{TRUE} selects chunking, \code{FALSE} implies contiguous storage, \code{NA} allows the NetCDF library to choose a storage layout. Ignored for scalar variables.}
+  \item{chunksizes}{(\code{"netcdf4"}) Chunk size expressed as the number of elements along each dimension, in the same order as \code{dimensions}. If \code{NULL}, the NetCDF library uses a default chunking strategy, which is intended to give reasonable performance in typical applications. Ignored unless \code{chunking} is \code{TRUE}.}
+  \item{deflate}{(\code{"netcdf4"}) Integer indicating level of compression, from 0 (minimum) to 9 (maximum), or \code{NA} for no compression.}
+  \item{shuffle}{(\code{"netcdf4"}) \code{TRUE} to enable byte shuffling, which may improve compression with \code{deflate}.}
+  \item{big_endian}{(\code{"netcdf4"}) Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for native endianness of the platform.}
+  \item{fletcher32}{(\code{"netcdf4"}) \code{TRUE} to enable the fletcher32 checksum.}
+  \item{filter_id}{(\code{"netcdf4"}) Vector of filter IDs to associate with the variable (empty vector denotes no filters). For information about the available filters, please see the NetCDF documentation. Ignored if the installed NetCDF library does not support the multi-filter interface.}
+  \item{filter_params}{(\code{"netcdf4"}) List with one element for each \code{filter_id}. Each list member is a vector of \code{numeric} parameters (which are converted to unsigned integers). The meaning of the parameters depends on the filter implementation, and RNetCDF is unable to perform any validation. Ignored if the installed NetCDF library does not support the multi-filter interface.}
 }
 
 \value{NetCDF variable identifier, returned invisibly.}

--- a/man/var.get.nc.Rd
+++ b/man/var.get.nc.Rd
@@ -11,6 +11,7 @@
   cache_bytes=NA, cache_slots=NA, cache_preemption=NA)}
 
 \arguments{
+  Arguments marked for "netcdf4" are optional for datasets in that format and ignored for other formats.
   \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{variable}{ID or name of the NetCDF variable.}
   \item{start}{A vector of indices specifying the element where reading starts along each dimension of \code{variable}. Indices are numbered from 1 onwards, and the order of dimensions is shown by \code{\link[RNetCDF]{print.nc}} (array elements are stored sequentially with leftmost indices varying fastest). By default (\code{start=NA}), all dimensions of \code{variable} are read from the first element onwards. Otherwise, \code{start} must be a vector whose length is not less than the number of dimensions in \code{variable} (excess elements are ignored). Any \code{NA} values in vector \code{start} are set to 1.}
@@ -33,11 +34,9 @@
     \code{NC_UINT64}     \tab \code{\link[bit64:bit64-package]{integer64}} \cr
   }}
 
-The arguments below apply only to datasets in "netcdf4" format. Reading and writing of variables involves a "chunk cache", and default cache settings are defined by the NetCDF library. Performance may be improved in some applications by adjusting the cache settings through the following options:
-
-  \item{cache_bytes}{Size of chunk cache in bytes. Value of \code{NA} (default) implies no change.}
-  \item{cache_slots}{Number of slots in chunk cache. Value of \code{NA} (default) implies no change.}
-  \item{cache_preemption}{Value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read. Value of \code{NA} (default) implies no change.}
+  \item{cache_bytes}{(netcdf4) Size of chunk cache in bytes. Value of \code{NA} (default) implies no change.}
+  \item{cache_slots}{(netcdf4) Number of slots in chunk cache. Value of \code{NA} (default) implies no change.}
+  \item{cache_preemption}{(netcdf4) Value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read. Value of \code{NA} (default) implies no change.}
 }
 
 \details{
@@ -57,7 +56,10 @@ Variables of user-defined types are supported. "compound" arrays are read into R
 
 The dimension order in the R array is reversed relative to the order reported by NetCDF commands such as \code{ncdump}, because NetCDF arrays are stored in row-major (C) order whereas R arrays are stored in column-major (Fortran) order.
 
-Arrays of type \code{character} drop the fastest-varying dimension of the corresponding \code{NC_CHAR} array, because this dimension corresponds to the length of the individual \code{character} elements. For example, an \code{NC_CHAR} array with dimensions (5,10) would be returned as a \code{character} vector containing 5 elements, each with a maximum length of 10 characters.}
+Arrays of type \code{character} drop the fastest-varying dimension of the corresponding \code{NC_CHAR} array, because this dimension corresponds to the length of the individual \code{character} elements. For example, an \code{NC_CHAR} array with dimensions (5,10) would be returned as a \code{character} vector containing 5 elements, each with a maximum length of 10 characters.
+
+The arguments marked for "netcdf4" format refer to the "chunk cache" used for reading and writing variables. Default cache settings are defined by the NetCDF library, and they can be adjusted for each variable to improve performance in some applications.
+}
 
 \references{\url{https://www.unidata.ucar.edu/software/netcdf/}}
 

--- a/man/var.get.nc.Rd
+++ b/man/var.get.nc.Rd
@@ -11,8 +11,8 @@
   cache_bytes=NA, cache_slots=NA, cache_preemption=NA)}
 
 \arguments{
-  Arguments marked for "netcdf4" are optional for datasets in that format and ignored for other formats.
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  Arguments marked \code{"netcdf4"} are optional for datasets in that format and ignored for other formats.
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{variable}{ID or name of the NetCDF variable.}
   \item{start}{A vector of indices specifying the element where reading starts along each dimension of \code{variable}. Indices are numbered from 1 onwards, and the order of dimensions is shown by \code{\link[RNetCDF]{print.nc}} (array elements are stored sequentially with leftmost indices varying fastest). By default (\code{start=NA}), all dimensions of \code{variable} are read from the first element onwards. Otherwise, \code{start} must be a vector whose length is not less than the number of dimensions in \code{variable} (excess elements are ignored). Any \code{NA} values in vector \code{start} are set to 1.}
   \item{count}{A vector of integers specifying the number of values to read along each dimension of \code{variable}. The order of dimensions is the same as for \code{start}. By default (\code{count=NA}), all dimensions of \code{variable} are read from \code{start} to end. Otherwise, \code{count} must be a vector whose length is not less than the number of dimensions in \code{variable} (excess elements are ignored). Any \code{NA} value in vector \code{count} indicates that the corresponding dimension should be read from the \code{start} index to the end of the dimension.}
@@ -34,15 +34,15 @@
     \code{NC_UINT64}     \tab \code{\link[bit64:bit64-package]{integer64}} \cr
   }}
 
-  \item{cache_bytes}{(netcdf4) Size of chunk cache in bytes. Value of \code{NA} (default) implies no change.}
-  \item{cache_slots}{(netcdf4) Number of slots in chunk cache. Value of \code{NA} (default) implies no change.}
-  \item{cache_preemption}{(netcdf4) Value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read. Value of \code{NA} (default) implies no change.}
+  \item{cache_bytes}{(\code{"netcdf4"}) Size of chunk cache in bytes. Value of \code{NA} (default) implies no change.}
+  \item{cache_slots}{(\code{"netcdf4"}) Number of slots in chunk cache. Value of \code{NA} (default) implies no change.}
+  \item{cache_preemption}{(\code{"netcdf4"}) Value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read. Value of \code{NA} (default) implies no change.}
 }
 
 \details{
 NetCDF numeric variables cannot portably represent \code{NA} values from R. NetCDF does allow attributes to be defined for variables, and several conventions exist for attributes that define missing values and valid ranges. The convention in use can be specified by argument \code{na.mode}. Values of a NetCDF variable that are deemed to be missing are automatically converted to \code{NA} in the results returned to R. Unusual cases can be handled directly in user code by setting \code{na.mode=3}.
 
-To reduce the storage space required by a NetCDF file, numeric variables are sometimes "packed" into types of lower precision. The original data can be recovered (approximately) by multiplication of the stored values by attribute \code{scale_factor} followed by addition of attribute \code{add_offset}. This unpacking operation is performed automatically for variables with attributes \code{scale_factor} and \code{add_offset} if argument \code{unpack} is set to \code{TRUE}. If \code{unpack} is \code{FALSE}, values are read from each variable without alteration.
+To reduce the storage space required by a NetCDF file, numeric variables are sometimes packed into types of lower precision. The original data can be recovered (approximately) by multiplication of the stored values by attribute \code{scale_factor} followed by addition of attribute \code{add_offset}. This unpacking operation is performed automatically for variables with attributes \code{scale_factor} and \code{add_offset} if argument \code{unpack} is set to \code{TRUE}. If \code{unpack} is \code{FALSE}, values are read from each variable without alteration.
 
 Data in a NetCDF variable is represented as a multi-dimensional array. The number and length of dimensions is determined when the variable is created. The \code{start} and \code{count} arguments of this routine indicate where the reading starts and the number of values to read along each dimension.
 
@@ -52,13 +52,13 @@ Awkwardness arises mainly from one thing: NetCDF data are written with the last 
 
 \value{An array with dimensions determined by \code{count} and a data type that depends on the type of \code{variable}. For NetCDF variables of type \code{NC_CHAR}, the R type is either \code{character} or \code{raw}, as specified by argument \code{rawchar}. For \code{NC_STRING}, the R type is \code{character}. Numeric variables are read as double precision by default, but the smallest R type that exactly represents each external type is used if \code{fitnum} is \code{TRUE}.
 
-Variables of user-defined types are supported. "compound" arrays are read into R as lists, with items named for the compound fields; items of base NetCDF data types are converted to R arrays, with leading dimensions from the field dimensions (if any) and trailing dimensions from the NetCDF variable. "enum" arrays are read into R as factor arrays. "opaque" arrays are read into R as raw (byte) arrays, with a leading dimension for bytes of the opaque type and trailing dimensions from the NetCDF variable. "vlen" arrays are read into R as a list with dimensions of the NetCDF variable; items in the list may have different lengths; base NetCDF data types are converted to R vectors.
+Variables of user-defined types are supported. \code{"compound"} arrays are read into R as lists, with items named for the compound fields; items of base NetCDF data types are converted to R arrays, with leading dimensions from the field dimensions (if any) and trailing dimensions from the NetCDF variable. \code{"enum"} arrays are read into R as factor arrays. \code{"opaque"} arrays are read into R as raw (byte) arrays, with a leading dimension for bytes of the opaque type and trailing dimensions from the NetCDF variable. \code{"vlen"} arrays are read into R as a list with dimensions of the NetCDF variable; items in the list may have different lengths; base NetCDF data types are converted to R vectors.
 
 The dimension order in the R array is reversed relative to the order reported by NetCDF commands such as \code{ncdump}, because NetCDF arrays are stored in row-major (C) order whereas R arrays are stored in column-major (Fortran) order.
 
 Arrays of type \code{character} drop the fastest-varying dimension of the corresponding \code{NC_CHAR} array, because this dimension corresponds to the length of the individual \code{character} elements. For example, an \code{NC_CHAR} array with dimensions (5,10) would be returned as a \code{character} vector containing 5 elements, each with a maximum length of 10 characters.
 
-The arguments marked for "netcdf4" format refer to the "chunk cache" used for reading and writing variables. Default cache settings are defined by the NetCDF library, and they can be adjusted for each variable to improve performance in some applications.
+The arguments marked for \code{"netcdf4"} format refer to the chunk cache used for reading and writing variables. Default cache settings are defined by the NetCDF library, and they can be adjusted for each variable to improve performance in some applications.
 }
 
 \references{\url{https://www.unidata.ucar.edu/software/netcdf/}}

--- a/man/var.inq.nc.Rd
+++ b/man/var.inq.nc.Rd
@@ -14,7 +14,7 @@
 }
 
 \value{
-  A list of named components, some of which are only included for datasets in "netcdf4" format (as indicated by \code{\link[RNetCDF]{file.inq.nc}}).
+  A list of named components, some of which are only included for datasets in "netcdf4" format (as reported by \code{\link[RNetCDF]{file.inq.nc}}).
   \item{id}{Variable ID.}
   \item{name}{Variable name.}
   \item{type}{External NetCDF data type as one of the following labels: \code{NC_BYTE}, \code{NC_UBYTE}, \code{NC_CHAR}, \code{NC_SHORT}, \code{NC_USHORT}, \code{NC_INT}, \code{NC_UINT}, \code{NC_INT64}, \code{NC_UINT64}, \code{NC_FLOAT}, \code{NC_DOUBLE}, \code{NC_STRING}, or a user-defined type name.}
@@ -22,23 +22,21 @@
   \item{dimids}{Vector of dimension IDs corresponding to the variable dimensions (\code{NA} for scalar variables). Order is leftmost varying fastest.}
   \item{natts}{Number of variable attributes assigned to this variable.}
 
-The list components below apply only to datasets in "netcdf4" format:
-
-  \item{chunksizes}{Chunk size expressed as the number of elements along each dimension, in the same order as \code{dimids}. \code{NULL} implies contiguous storage.}
-  \item{cache_bytes}{Size of chunk cache in bytes (\code{NULL} if unsupported).}
-  \item{cache_slots}{The number of slots in the chunk cache (\code{NULL} if unsupported).}
-  \item{cache_preemption}{A value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read (\code{NULL} if unsupported).}
-  \item{deflate}{Integer indicating level of compression, from 0 (minimum) to 9 (maximum), or \code{NA} if compression is not enabled.}
-  \item{shuffle}{\code{TRUE} if byte shuffling is enabled for the variable, \code{FALSE} otherwise.}
-  \item{big_endian}{Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for not yet determined, or \code{NULL} if unsupported.}
-  \item{fletcher32}{\code{TRUE} if the fletcher32 checksum is enabled for this variable, \code{FALSE} otherwise.}
-  \item{szip_options}{Integer containing a bitmask of szip options. \code{NA} if szip is not used, or \code{NULL} if unsupported.}
-  \item{szip_bits}{Number of bits per pixel for szip. \code{NA} if szip is not used, or \code{NULL} if unsupported.}
-  \item{filter_id}{Vector of filter IDs associated with the variable, or \code{NULL} if the NetCDF library does not support the multi-filter interface.}
-  \item{filter_params}{List with one element per \code{filter_id}, or \code{NULL} if the NetCDF library does not support the multi-filter interface. Each list member is a vector of \code{numeric} parameters for the corresponding filter. Please see the NetCDF documentation for information about the available filters and their parameters.}
+  \item{chunksizes}{(netcdf4) Chunk size expressed as the number of elements along each dimension, in the same order as \code{dimids}. \code{NULL} implies contiguous storage.}
+  \item{cache_bytes}{(netcdf4) Size of chunk cache in bytes (\code{NULL} if unsupported).}
+  \item{cache_slots}{(netcdf4) The number of slots in the chunk cache (\code{NULL} if unsupported).}
+  \item{cache_preemption}{(netcdf4) A value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read (\code{NULL} if unsupported).}
+  \item{deflate}{(netcdf4) Integer indicating level of compression, from 0 (minimum) to 9 (maximum), or \code{NA} if compression is not enabled.}
+  \item{shuffle}{(netcdf4) \code{TRUE} if byte shuffling is enabled for the variable, \code{FALSE} otherwise.}
+  \item{big_endian}{(netcdf4) Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for not yet determined, or \code{NULL} if unsupported.}
+  \item{fletcher32}{(netcdf4) \code{TRUE} if the fletcher32 checksum is enabled for this variable, \code{FALSE} otherwise.}
+  \item{szip_options}{(netcdf4) Integer containing a bitmask of szip options. \code{NA} if szip is not used, or \code{NULL} if unsupported.}
+  \item{szip_bits}{(netcdf4) Number of bits per pixel for szip. \code{NA} if szip is not used, or \code{NULL} if unsupported.}
+  \item{filter_id}{(netcdf4) Vector of filter IDs associated with the variable, or \code{NULL} if the NetCDF library does not support the multi-filter interface.}
+  \item{filter_params}{(netcdf4) List with one element per \code{filter_id}, or \code{NULL} if the NetCDF library does not support the multi-filter interface. Each list member is a vector of \code{numeric} parameters for the corresponding filter. Please see the NetCDF documentation for information about the available filters and their parameters.}
 }
 
-\details{This function returns information about a NetCDF variable. Information about a variable include its name, its ID, its type, its number of dimensions, a vector of the dimension IDs of this variable and the number of attributes.}
+\details{This function returns information about a NetCDF variable, including its name, ID, type, number of dimensions, a vector of the dimension IDs, and the number of attributes.}
 
 \references{\url{https://www.unidata.ucar.edu/software/netcdf/}}
 

--- a/man/var.inq.nc.Rd
+++ b/man/var.inq.nc.Rd
@@ -9,12 +9,12 @@
 \usage{var.inq.nc(ncfile, variable)}
 
 \arguments{
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{variable}{Either the ID or the name of the variable to be inquired.}
 }
 
 \value{
-  A list of named components, some of which are only included for datasets in "netcdf4" format (as reported by \code{\link[RNetCDF]{file.inq.nc}}).
+  A list of named components, some of which are only included for datasets in \code{"netcdf4"} format (as reported by \code{\link[RNetCDF]{file.inq.nc}}).
   \item{id}{Variable ID.}
   \item{name}{Variable name.}
   \item{type}{External NetCDF data type as one of the following labels: \code{NC_BYTE}, \code{NC_UBYTE}, \code{NC_CHAR}, \code{NC_SHORT}, \code{NC_USHORT}, \code{NC_INT}, \code{NC_UINT}, \code{NC_INT64}, \code{NC_UINT64}, \code{NC_FLOAT}, \code{NC_DOUBLE}, \code{NC_STRING}, or a user-defined type name.}
@@ -22,18 +22,18 @@
   \item{dimids}{Vector of dimension IDs corresponding to the variable dimensions (\code{NA} for scalar variables). Order is leftmost varying fastest.}
   \item{natts}{Number of variable attributes assigned to this variable.}
 
-  \item{chunksizes}{(netcdf4) Chunk size expressed as the number of elements along each dimension, in the same order as \code{dimids}. \code{NULL} implies contiguous storage.}
-  \item{cache_bytes}{(netcdf4) Size of chunk cache in bytes (\code{NULL} if unsupported).}
-  \item{cache_slots}{(netcdf4) The number of slots in the chunk cache (\code{NULL} if unsupported).}
-  \item{cache_preemption}{(netcdf4) A value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read (\code{NULL} if unsupported).}
-  \item{deflate}{(netcdf4) Integer indicating level of compression, from 0 (minimum) to 9 (maximum), or \code{NA} if compression is not enabled.}
-  \item{shuffle}{(netcdf4) \code{TRUE} if byte shuffling is enabled for the variable, \code{FALSE} otherwise.}
-  \item{big_endian}{(netcdf4) Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for not yet determined, or \code{NULL} if unsupported.}
-  \item{fletcher32}{(netcdf4) \code{TRUE} if the fletcher32 checksum is enabled for this variable, \code{FALSE} otherwise.}
-  \item{szip_options}{(netcdf4) Integer containing a bitmask of szip options. \code{NA} if szip is not used, or \code{NULL} if unsupported.}
-  \item{szip_bits}{(netcdf4) Number of bits per pixel for szip. \code{NA} if szip is not used, or \code{NULL} if unsupported.}
-  \item{filter_id}{(netcdf4) Vector of filter IDs associated with the variable, or \code{NULL} if the NetCDF library does not support the multi-filter interface.}
-  \item{filter_params}{(netcdf4) List with one element per \code{filter_id}, or \code{NULL} if the NetCDF library does not support the multi-filter interface. Each list member is a vector of \code{numeric} parameters for the corresponding filter. Please see the NetCDF documentation for information about the available filters and their parameters.}
+  \item{chunksizes}{(\code{"netcdf4"}) Chunk size expressed as the number of elements along each dimension, in the same order as \code{dimids}. \code{NULL} implies contiguous storage.}
+  \item{cache_bytes}{(\code{"netcdf4"}) Size of chunk cache in bytes (\code{NULL} if unsupported).}
+  \item{cache_slots}{(\code{"netcdf4"}) The number of slots in the chunk cache (\code{NULL} if unsupported).}
+  \item{cache_preemption}{(\code{"netcdf4"}) A value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read (\code{NULL} if unsupported).}
+  \item{deflate}{(\code{"netcdf4"}) Integer indicating level of compression, from 0 (minimum) to 9 (maximum), or \code{NA} if compression is not enabled.}
+  \item{shuffle}{(\code{"netcdf4"}) \code{TRUE} if byte shuffling is enabled for the variable, \code{FALSE} otherwise.}
+  \item{big_endian}{(\code{"netcdf4"}) Byte order of the variable. \code{TRUE} for big-endian, \code{FALSE} for little-endian, \code{NA} for not yet determined, or \code{NULL} if unsupported.}
+  \item{fletcher32}{(\code{"netcdf4"}) \code{TRUE} if the fletcher32 checksum is enabled for this variable, \code{FALSE} otherwise.}
+  \item{szip_options}{(\code{"netcdf4"}) Integer containing a bitmask of szip options. \code{NA} if szip is not used, or \code{NULL} if unsupported.}
+  \item{szip_bits}{(\code{"netcdf4"}) Number of bits per pixel for szip. \code{NA} if szip is not used, or \code{NULL} if unsupported.}
+  \item{filter_id}{(\code{"netcdf4"}) Vector of filter IDs associated with the variable, or \code{NULL} if the NetCDF library does not support the multi-filter interface.}
+  \item{filter_params}{(\code{"netcdf4"}) List with one element per \code{filter_id}, or \code{NULL} if the NetCDF library does not support the multi-filter interface. Each list member is a vector of \code{numeric} parameters for the corresponding filter. Please see the NetCDF documentation for information about the available filters and their parameters.}
 }
 
 \details{This function returns information about a NetCDF variable, including its name, ID, type, number of dimensions, a vector of the dimension IDs, and the number of attributes.}

--- a/man/var.par.nc.Rd
+++ b/man/var.par.nc.Rd
@@ -9,7 +9,7 @@
 \usage{var.par.nc(ncfile, variable, access="NC_COLLECTIVE")}
 
 \arguments{
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{variable}{Numeric ID or name of the variable for which to change the parallel access mode. Use "NC_GLOBAL" to change the parallel access mode for all variables in the dataset.}
   \item{access}{Parallel access mode as one of the following strings: "\code{NC_COLLECTIVE}" or "\code{NC_INDEPENDENT}".}
 }
@@ -18,7 +18,7 @@
 
 All netCDF metadata writing operations are collective - all creation of groups, types, variables, dimensions, or attributes.
 
-Note that when the file format is "classic" or "offset64", the change always applies to all variables in the file, even if a single variable is specified in argument \code{variable}.}
+Note that when the file format is \code{"classic"} or \code{"offset64"}, the change always applies to all variables in the file, even if a single variable is specified in argument \code{variable}.}
 
 \references{\url{https://www.unidata.ucar.edu/software/netcdf/}}
 

--- a/man/var.put.nc.Rd
+++ b/man/var.put.nc.Rd
@@ -10,8 +10,8 @@
   cache_bytes=NA, cache_slots=NA, cache_preemption=NA)}
 
 \arguments{
-  Arguments marked for "netcdf4" are optional for datasets in that format and ignored for other formats.
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  Arguments marked \code{"netcdf4"} are optional for datasets in that format and ignored for other formats.
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{variable}{ID or name of the NetCDF variable.}
   \item{data}{An R vector or array of data to be written to the NetCDF variable. Values are taken from \code{data} in the order of R vector elements, so that leftmost indices vary fastest over an array.}
   \item{start}{A vector of indices specifying the element where writing starts along each dimension of \code{variable}. Indices are numbered from 1 onwards, and the order of dimensions is shown by \code{\link[RNetCDF]{print.nc}} (array elements are stored sequentially with leftmost indices varying fastest). By default (\code{start=NA}), all dimensions of \code{variable} are written from the first element onwards. Otherwise, \code{start} must be a vector whose length is not less than the number of dimensions in \code{variable} (excess elements are ignored). Any \code{NA} values in vector \code{start} are set to 1.}
@@ -19,9 +19,9 @@
   \item{na.mode}{Set the mode for handling missing values (\code{NA}) in numeric variables: 0=accept \code{_FillValue}, then \code{missing_value} attribute; 1=accept only \code{_FillValue} attribute; 2=accept only \code{missing_value} attribute; 3=no missing value conversion; 4=valid range from valid_min and valid_max or valid_range, fill value from _FillValue, with defaults for each type except \code{NC_BYTE} and \code{NC_UBYTE} (see \url{https://www.unidata.ucar.edu/software/netcdf/documentation/NUG/attribute_conventions.html}).}
   \item{pack}{Variables are packed if \code{pack=TRUE} and the attributes \code{add_offset} and \code{scale_factor} are defined. Default is \code{FALSE}.}
 
-  \item{cache_bytes}{(netcdf4) Size of chunk cache in bytes. Value of \code{NA} (default) implies no change.}
-  \item{cache_slots}{(netcdf4) Number of slots in chunk cache. Value of \code{NA} (default) implies no change.}
-  \item{cache_preemption}{(netcdf4) Value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read. Value of \code{NA} (default) implies no change.}
+  \item{cache_bytes}{(\code{"netcdf4"}) Size of chunk cache in bytes. Value of \code{NA} (default) implies no change.}
+  \item{cache_slots}{(\code{"netcdf4"}) Number of slots in chunk cache. Value of \code{NA} (default) implies no change.}
+  \item{cache_preemption}{(\code{"netcdf4"}) Value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read. Value of \code{NA} (default) implies no change.}
 }
 
 \details{This function writes values to a NetCDF variable. Data values in R are automatically converted to the correct type of NetCDF variable.
@@ -32,15 +32,15 @@ Due to the lack of native support for 64-bit integers in R, NetCDF types \code{N
 
 NetCDF numeric variables cannot portably represent \code{NA} values from R. NetCDF does allow attributes to be defined for variables, and several conventions exist for attributes that define missing values and valid ranges. The convention in use can be specified by argument \code{na.mode}. Values of \code{NA} in argument \code{data} are converted to a missing or fill value before writing to the NetCDF variable. Unusual cases can be handled directly in user code by setting \code{na.mode=3}.
 
-Variables of user-defined types are supported, subject to conditions on the corresponding data structures in R. "compound" arrays must be stored in R as lists, with items named for the compound fields; items of base NetCDF data types are stored as R arrays, with leading dimensions from the field dimensions (if any) and trailing dimensions from the NetCDF variable. "enum" arrays are stored in R as factor arrays. "opaque" arrays are stored in R as raw (byte) arrays, with a leading dimension for bytes of the opaque type and trailing dimensions from the NetCDF variable. "vlen" arrays are stored in R as a list with dimensions of the NetCDF variable; items in the list may have different lengths; base NetCDF data types are stored as R vectors.
+Variables of user-defined types are supported, subject to conditions on the corresponding data structures in R. \code{"compound"} arrays must be stored in R as lists, with items named for the compound fields; items of base NetCDF data types are stored as R arrays, with leading dimensions from the field dimensions (if any) and trailing dimensions from the NetCDF variable. \code{"enum"} arrays are stored in R as factor arrays. \code{"opaque"} arrays are stored in R as raw (byte) arrays, with a leading dimension for bytes of the opaque type and trailing dimensions from the NetCDF variable. \code{"vlen"} arrays are stored in R as a list with dimensions of the NetCDF variable; items in the list may have different lengths; base NetCDF data types are stored as R vectors.
 
-To reduce the storage space required by a NetCDF file, numeric variables can be "packed" into types of lower precision. The packing operation involves subtraction of attribute \code{add_offset} before division by attribute \code{scale_factor}. This packing operation is performed automatically for variables defined with the two attributes \code{add_offset} and \code{scale_factor} if argument \code{pack} is set to \code{TRUE}. If \code{pack} is \code{FALSE}, \code{data} values are assumed to be packed correctly and are written to the variable without alteration.
+To reduce the storage space required by a NetCDF file, numeric variables can be packed into types of lower precision. The packing operation involves subtraction of attribute \code{add_offset} before division by attribute \code{scale_factor}. This packing operation is performed automatically for variables defined with the two attributes \code{add_offset} and \code{scale_factor} if argument \code{pack} is set to \code{TRUE}. If \code{pack} is \code{FALSE}, \code{data} values are assumed to be packed correctly and are written to the variable without alteration.
 
 Data in a NetCDF variable is represented as a multi-dimensional array. The number and length of dimensions is determined when the variable is created. The \code{start} and \code{count} arguments of this routine indicate where the writing starts and the number of values to write along each dimension.
 
 Awkwardness arises mainly from one thing: NetCDF data are written with the last dimension varying fastest, whereas R works opposite. Thus, the order of the dimensions according to the CDL conventions (e.g., time, latitude, longitude) is reversed in the R array (e.g., longitude, latitude, time).
 
-The arguments marked for "netcdf4" format refer to the "chunk cache" used for reading and writing variables. Default cache settings are defined by the NetCDF library, and they can be adjusted for each variable to improve performance in some applications.
+The arguments marked for \code{"netcdf4"} format refer to the chunk cache used for reading and writing variables. Default cache settings are defined by the NetCDF library, and they can be adjusted for each variable to improve performance in some applications.
 }
 
 \references{\url{https://www.unidata.ucar.edu/software/netcdf/}}

--- a/man/var.put.nc.Rd
+++ b/man/var.put.nc.Rd
@@ -10,6 +10,7 @@
   cache_bytes=NA, cache_slots=NA, cache_preemption=NA)}
 
 \arguments{
+  Arguments marked for "netcdf4" are optional for datasets in that format and ignored for other formats.
   \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{variable}{ID or name of the NetCDF variable.}
   \item{data}{An R vector or array of data to be written to the NetCDF variable. Values are taken from \code{data} in the order of R vector elements, so that leftmost indices vary fastest over an array.}
@@ -18,11 +19,9 @@
   \item{na.mode}{Set the mode for handling missing values (\code{NA}) in numeric variables: 0=accept \code{_FillValue}, then \code{missing_value} attribute; 1=accept only \code{_FillValue} attribute; 2=accept only \code{missing_value} attribute; 3=no missing value conversion; 4=valid range from valid_min and valid_max or valid_range, fill value from _FillValue, with defaults for each type except \code{NC_BYTE} and \code{NC_UBYTE} (see \url{https://www.unidata.ucar.edu/software/netcdf/documentation/NUG/attribute_conventions.html}).}
   \item{pack}{Variables are packed if \code{pack=TRUE} and the attributes \code{add_offset} and \code{scale_factor} are defined. Default is \code{FALSE}.}
 
-The arguments below apply only to datasets in "netcdf4" format. Reading and writing of variables involves a "chunk cache", and default cache settings are defined by the NetCDF library. Performance may be improved in some applications by adjusting the cache settings through the following options:
-
-  \item{cache_bytes}{Size of chunk cache in bytes. Value of \code{NA} (default) implies no change.}
-  \item{cache_slots}{Number of slots in chunk cache. Value of \code{NA} (default) implies no change.}
-  \item{cache_preemption}{Value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read. Value of \code{NA} (default) implies no change.}
+  \item{cache_bytes}{(netcdf4) Size of chunk cache in bytes. Value of \code{NA} (default) implies no change.}
+  \item{cache_slots}{(netcdf4) Number of slots in chunk cache. Value of \code{NA} (default) implies no change.}
+  \item{cache_preemption}{(netcdf4) Value between 0 and 1 (inclusive) that biases the cache scheme towards eviction of chunks that have been fully read. Value of \code{NA} (default) implies no change.}
 }
 
 \details{This function writes values to a NetCDF variable. Data values in R are automatically converted to the correct type of NetCDF variable.
@@ -39,7 +38,10 @@ To reduce the storage space required by a NetCDF file, numeric variables can be 
 
 Data in a NetCDF variable is represented as a multi-dimensional array. The number and length of dimensions is determined when the variable is created. The \code{start} and \code{count} arguments of this routine indicate where the writing starts and the number of values to write along each dimension.
 
-Awkwardness arises mainly from one thing: NetCDF data are written with the last dimension varying fastest, whereas R works opposite. Thus, the order of the dimensions according to the CDL conventions (e.g., time, latitude, longitude) is reversed in the R array (e.g., longitude, latitude, time).}
+Awkwardness arises mainly from one thing: NetCDF data are written with the last dimension varying fastest, whereas R works opposite. Thus, the order of the dimensions according to the CDL conventions (e.g., time, latitude, longitude) is reversed in the R array (e.g., longitude, latitude, time).
+
+The arguments marked for "netcdf4" format refer to the "chunk cache" used for reading and writing variables. Default cache settings are defined by the NetCDF library, and they can be adjusted for each variable to improve performance in some applications.
+}
 
 \references{\url{https://www.unidata.ucar.edu/software/netcdf/}}
 

--- a/man/var.rename.nc.Rd
+++ b/man/var.rename.nc.Rd
@@ -9,7 +9,7 @@
 \usage{var.rename.nc(ncfile, variable, newname)}
 
 \arguments{
-  \item{ncfile}{Object of class "\code{NetCDF}" which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
+  \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{variable}{Either the ID or the name of the variable to be renamed.}
   \item{newname}{The new variable name.}
 }

--- a/src/variable.c
+++ b/src/variable.c
@@ -523,7 +523,7 @@ R_nc_get_var (SEXP nc, SEXP var, SEXP start, SEXP count,
   size_t fillsize;
 
 #ifdef HAVE_NC_GET_VAR_CHUNK_CACHE
-  int storeprop;
+  int storeprop, format, withnc4;
   size_t bytes, slots;
   float preemption;
   double bytes_in, slots_in, preempt_in;
@@ -541,25 +541,29 @@ R_nc_get_var (SEXP nc, SEXP var, SEXP start, SEXP count,
 
   /*-- Chunk cache options for netcdf4 files ----------------------------------*/
 #ifdef HAVE_NC_GET_VAR_CHUNK_CACHE
-  R_nc_check (nc_inq_var_chunking (ncid, varid, &storeprop, NULL));
-  if (storeprop == NC_CHUNKED) {
-    R_nc_check (nc_get_var_chunk_cache(ncid, varid,
-                                       &bytes, &slots, &preemption));
-    bytes_in = asReal (cache_bytes);
-    slots_in = asReal (cache_slots);
-    preempt_in = asReal (cache_preemption);
-    if (R_FINITE(bytes_in) || R_FINITE(slots_in) || R_FINITE(preempt_in)) {
-      if (R_FINITE(bytes_in)) {
-	bytes = bytes_in;
+  R_nc_check (nc_inq_format (ncid, &format));
+  withnc4 = (format == NC_FORMAT_NETCDF4);
+  if (withnc4) {
+    R_nc_check (nc_inq_var_chunking (ncid, varid, &storeprop, NULL));
+    if (storeprop == NC_CHUNKED) {
+      R_nc_check (nc_get_var_chunk_cache(ncid, varid,
+					 &bytes, &slots, &preemption));
+      bytes_in = asReal (cache_bytes);
+      slots_in = asReal (cache_slots);
+      preempt_in = asReal (cache_preemption);
+      if (R_FINITE(bytes_in) || R_FINITE(slots_in) || R_FINITE(preempt_in)) {
+	if (R_FINITE(bytes_in)) {
+	  bytes = bytes_in;
+	}
+	if (R_FINITE(slots_in)) {
+	  slots = slots_in;
+	}
+	if (R_FINITE(preempt_in)) {
+	  preemption = preempt_in;
+	}
+	R_nc_check (nc_set_var_chunk_cache(ncid, varid,
+					   bytes, slots, preemption));
       }
-      if (R_FINITE(slots_in)) {
-	slots = slots_in;
-      }
-      if (R_FINITE(preempt_in)) {
-	preemption = preempt_in;
-      }
-      R_nc_check (nc_set_var_chunk_cache(ncid, varid,
-                                         bytes, slots, preemption));
     }
   }
 #endif
@@ -878,7 +882,7 @@ R_nc_put_var (SEXP nc, SEXP var, SEXP start, SEXP count, SEXP data,
   size_t fillsize;
 
 #ifdef HAVE_NC_GET_VAR_CHUNK_CACHE
-  int storeprop;
+  int storeprop, format, withnc4;
   size_t bytes, slots;
   float preemption;
   double bytes_in, slots_in, preempt_in;
@@ -894,25 +898,29 @@ R_nc_put_var (SEXP nc, SEXP var, SEXP start, SEXP count, SEXP data,
 
   /*-- Chunk cache options for netcdf4 files ----------------------------------*/
 #ifdef HAVE_NC_GET_VAR_CHUNK_CACHE
-  R_nc_check (nc_inq_var_chunking (ncid, varid, &storeprop, NULL));
-  if (storeprop == NC_CHUNKED) {
-    R_nc_check (nc_get_var_chunk_cache(ncid, varid,
-                                       &bytes, &slots, &preemption));
-    bytes_in = asReal (cache_bytes);
-    slots_in = asReal (cache_slots);
-    preempt_in = asReal (cache_preemption);
-    if (R_FINITE(bytes_in) || R_FINITE(slots_in) || R_FINITE(preempt_in)) {
-      if (R_FINITE(bytes_in)) {
-	bytes = bytes_in;
+  R_nc_check (nc_inq_format (ncid, &format));
+  withnc4 = (format == NC_FORMAT_NETCDF4);
+  if (withnc4) {
+    R_nc_check (nc_inq_var_chunking (ncid, varid, &storeprop, NULL));
+    if (storeprop == NC_CHUNKED) {
+      R_nc_check (nc_get_var_chunk_cache(ncid, varid,
+					 &bytes, &slots, &preemption));
+      bytes_in = asReal (cache_bytes);
+      slots_in = asReal (cache_slots);
+      preempt_in = asReal (cache_preemption);
+      if (R_FINITE(bytes_in) || R_FINITE(slots_in) || R_FINITE(preempt_in)) {
+	if (R_FINITE(bytes_in)) {
+	  bytes = bytes_in;
+	}
+	if (R_FINITE(slots_in)) {
+	  slots = slots_in;
+	}
+	if (R_FINITE(preempt_in)) {
+	  preemption = preempt_in;
+	}
+	R_nc_check (nc_set_var_chunk_cache(ncid, varid,
+					   bytes, slots, preemption));
       }
-      if (R_FINITE(slots_in)) {
-	slots = slots_in;
-      }
-      if (R_FINITE(preempt_in)) {
-	preemption = preempt_in;
-      }
-      R_nc_check (nc_set_var_chunk_cache(ncid, varid,
-                                         bytes, slots, preemption));
     }
   }
 #endif


### PR DESCRIPTION
@fenclmar created PR #99 to demonstrate that a function argument specific to netcdf4 format could be identified more clearly in help files, and this PR follows a similar approach for more arguments.

Some additional source code has been added so that netcdf4-specific arguments are ignored for other formats, as claimed in the help files.

Character literals are double-quoted inside `\code{}` blocks, so that help files are formatted consistently in different locales.