### PR TITLE
Avoid use of sprintf when generating convert.c

### DIFF
--- a/tools/convert.m4
+++ b/tools/convert.m4
@@ -1163,7 +1163,7 @@ R_nc_char_symbol (char *in, size_t size, char *work)
   size_t ii;
   work[0]='X';
   for (ii=0; ii<size; ii++) {
-    sprintf(work+1+ii*2, "%02X", in[ii]);
+    snprintf(work+1+ii*2, 3, "%02X", in[ii]);
   }
   work[2*size+1]='\0';
   return install(work);


### PR DESCRIPTION
This PR ensure that changes in #107 are not undone if src/convert.c is regenerated from tools/convert.m4.