### PR TITLE
Support fill value conversion in NC_STRING type

### DIFF
--- a/configure
+++ b/configure
@@ -3934,6 +3934,12 @@ then :
   printf "%s\n" "#define HAVE_NC_VAR_PAR_ACCESS 1" >>confdefs.h
 
 fi
+ac_fn_c_check_func "$LINENO" "nc_reclaim_data" "ac_cv_func_nc_reclaim_data"
+if test "x$ac_cv_func_nc_reclaim_data" = xyes
+then :
+  printf "%s\n" "#define HAVE_NC_RECLAIM_DATA 1" >>confdefs.h
+
+fi
 
 
 # Check for parallel header file.

--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ AC_SEARCH_LIBS(nc_open, netcdf, [],
 # C preprocessor macros HAVE_routine are defined for existing routines.
 AC_CHECK_FUNCS([nc_rename_grp nc_get_var_chunk_cache nc_inq_var_szip \
   nc_inq_var_endian nc_def_var_filter nc_inq_var_filter_ids nc_inq_var_filter_info \
-  nc_create_par_fortran nc_open_par_fortran nc_var_par_access])
+  nc_create_par_fortran nc_open_par_fortran nc_var_par_access nc_reclaim_data])
 
 # Check for parallel header file.
 AC_CHECK_HEADERS(netcdf_par.h, [], [], [#include <netcdf.h>])

--- a/tools/convert.m4
+++ b/tools/convert.m4
@@ -310,17 +310,29 @@ R_nc_char_raw (R_nc_buf *io)
 
 
 static const char **
-R_nc_strsxp_str (SEXP rstr, int ndim, const size_t *xdim)
+R_nc_strsxp_str (SEXP rstr, int ndim, const size_t *xdim,
+                 size_t fillsize, const void *fill)
 {
   size_t ii, cnt;
-  const char **cstr;
+  const char **cstr, *fillval;
+  SEXP thissxp;
+  int hasfill;
+  hasfill = (fill != NULL && fillsize == sizeof (size_t));
+  if (hasfill) {
+    fillval = *(const char **) fill;
+  }
   cnt = R_nc_length (ndim, xdim);
   if ((size_t) xlength (rstr) < cnt) {
     error (RNC_EDATALEN);
   }
   cstr = (const char **) R_alloc (cnt, sizeof(size_t));
   for (ii=0; ii<cnt; ii++) {
-    cstr[ii] = CHAR( STRING_ELT (rstr, ii));
+    thissxp = STRING_ELT (rstr, ii);
+    if (hasfill && thissxp == NA_STRING) {
+      cstr[ii] = fillval;
+    } else {
+      cstr[ii] = CHAR(thissxp);
+    }
   }
   return cstr;
 }
@@ -343,15 +355,21 @@ R_nc_str_strsxp (R_nc_buf *io)
 {
   size_t ii, nchar, cnt;
   char **cstr;
+  const char *fillval;
+  int hasfill;
+  hasfill = (io->fill != NULL && io->fillsize == sizeof (size_t));
+  if (hasfill) {
+    fillval = *(const char **) io->fill;
+  }
   cnt = xlength (io->rxp);
   cstr = (char **) io->cbuf;
   for (ii=0; ii<cnt; ii++) {
-    nchar = strlen (cstr[ii]);
-    if (nchar > RNC_CHARSXP_MAXLEN) {
+    if (hasfill && strcmp (cstr[ii], fillval) == 0) {
+      SET_STRING_ELT (io->rxp, ii, NA_STRING);
+    } else {
       /* Truncate excessively long strings while reading into R */
-      SET_STRING_ELT (io->rxp, ii, mkCharLen (cstr[ii], RNC_CHARSXP_MAXLEN));
-    } else if (nchar > 0) {
-      SET_STRING_ELT (io->rxp, ii, mkChar (cstr[ii]));
+      nchar = R_nc_strnlen (cstr[ii], '\0', RNC_CHARSXP_MAXLEN);
+      SET_STRING_ELT (io->rxp, ii, mkCharLen (cstr[ii], nchar));
     }
   }
   /* Free pointers to strings created by netcdf */
@@ -1693,7 +1711,7 @@ R_nc_r2c (SEXP rv, int ncid, nc_type xtype, int ndim, const size_t *xdim,
     case NC_CHAR:
       return R_nc_strsxp_char (rv, ndim, xdim, fillsize, fill);
     case NC_STRING:
-      return R_nc_strsxp_str (rv, ndim, xdim);
+      return R_nc_strsxp_str (rv, ndim, xdim, fillsize, fill);
     }
     break;
   case RAWSXP:


### PR DESCRIPTION
The NetCDF library honours the `_FillValue` attribute of NC_STRING variables, filling unwritten strings with the specified value. This PR adds support for fill values when na.mode=5 is set for `var.put.nc` or `var.get.nc`.

When writing R strings to an NC_STRING variable, `NA` values are replaced by the `_FillValue` string. The opposite applies when reading NC_STRING variables into R strings.