### PR TITLE
Support fill value conversion in vlen types

### DIFF
--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -212,6 +212,7 @@ for (format in c("classic","offset64","data64","classic4","netcdf4")) {
     var.def.nc(nc, "namestr", "NC_STRING", c("station"))
     var.def.nc(nc, "namestr_fill", "NC_STRING", c("station"))
     var.def.nc(nc, "profile", id_vector, c("station","time"))
+    var.def.nc(nc, "profile_fill", id_vector, c("station","time"))
     var.def.nc(nc, "profile_pack", id_vector, c("station","time"))
     att.put.nc(nc, "profile_pack", "scale_factor", "NC_FLOAT", 10)
     var.def.nc(nc, "profile_char", id_vector_char, c("station","time"))
@@ -225,7 +226,7 @@ for (format in c("classic","offset64","data64","classic4","netcdf4")) {
     var.def.nc(nc, "snacks_empty", "factor", c("station", "time"))
     var.def.nc(nc, "person", "struct", c("station", "time"))
     var.def.nc(nc, "person_fill", "struct", c("station", "time"))
-    varcnt <- varcnt+15
+    varcnt <- varcnt+16
 
     if (package_version(verstr) >= package_version("4.9.0")) {
       var.def.nc(nc, "profile_vector", id_vector_vector, c("station","time"))
@@ -488,6 +489,11 @@ for (format in c("classic","offset64","data64","classic4","netcdf4")) {
       profiles_vector_fill[[3]][[2]][5] <- NA
     }
 
+    profiles_fill <- profiles
+    profiles_fillval <- list(-999999999)
+    profiles[[3]][2] <- -999999999
+    profiles_fill[[3]][2] <- NA
+
     rawdata <- as.raw(seq_len(nstation*ntime*128) %% 256)
     dim(rawdata) <- c(128,nstation,ntime)
 
@@ -539,6 +545,8 @@ for (format in c("classic","offset64","data64","classic4","netcdf4")) {
     att.put.nc(nc, "namestr_fill", "_FillValue", "NC_STRING", "_MISSING")
     att.put.nc(nc, "snacks", "_FillValue", "factor", factor("NA"))
     att.put.nc(nc, "person_fill", "_FillValue", "struct", person_fillval)
+    att.put.nc(nc, "profile_fill", "_FillValue", id_vector,
+               profiles_fillval)
 
     if (package_version(verstr) >= package_version("4.9.0")) {
       att.put.nc(nc, "profile_vector_fill", "_FillValue", id_vector_vector,
@@ -564,6 +572,7 @@ for (format in c("classic","offset64","data64","classic4","netcdf4")) {
     var.put.nc(nc, "namestr", mynamestr_fill)
     var.put.nc(nc, "namestr_fill", mynamestr_fill, na.mode=5)
     var.put.nc(nc, "profile", profiles)
+    var.put.nc(nc, "profile_fill", profiles_fill, na.mode=5)
     var.put.nc(nc, "profile_pack", profiles, pack=TRUE)
     var.put.nc(nc, "profile_char", profiles_char)
     var.put.nc(nc, "profile_string", profiles_string)
@@ -1141,6 +1150,11 @@ for (format in c("classic","offset64","data64","classic4","netcdf4")) {
     y <- var.get.nc(nc, "profile", fitnum=TRUE)
     tally <- testfun(x,y,tally)
     tally <- testfun(isTRUE(all(sapply(y,is.integer))), TRUE, tally)
+
+    cat("Read vlen with fill ...")
+    x <- profiles_fill
+    y <- var.get.nc(nc, "profile_fill", na.mode=5)
+    tally <- testfun(x,y,tally)
 
     cat("Read vlen scalar ...")
     x <- profiles[1]

--- a/tools/convert.m4
+++ b/tools/convert.m4
@@ -1035,20 +1035,43 @@ R_nc_vlen_vecsxp_init (R_nc_buf *io)
 static void
 R_nc_vlen_vecsxp (R_nc_buf *io)
 {
-  size_t ii, cnt;
+  size_t ii, cnt, size, basesize, basefillsize;
   nc_type basetype;
-  nc_vlen_t *vbuf;
+  nc_vlen_t *vbuf, *vfill;
   R_nc_buf tmpio;
   SEXP tmprxp;
+  int baseclass, hasfill;
+  const void *basefill;
 
   vbuf = io->cbuf;
   cnt = xlength (io->rxp);
-  R_nc_check (nc_inq_user_type (io->ncid, io->xtype, NULL, NULL, &basetype, NULL, NULL));
 
+  R_nc_check (nc_inq_user_type (io->ncid, io->xtype, NULL, &size, &basetype, NULL, NULL));
+  if (basetype > NC_MAX_ATOMIC_TYPE) {
+    R_nc_check (nc_inq_user_type (io->ncid, basetype, NULL, &basesize, NULL, NULL, &baseclass));
+  } else {
+    R_nc_check (nc_inq_type (io->ncid, basetype, NULL, &basesize)); 
+    baseclass = NC_NAT;
+  }
+
+  /* Check if fill value is properly defined */
+  hasfill = (io->fill != NULL &&
+             io->fillsize == size);
+  basefill = NULL;
+  basefillsize = 0;
+  if (hasfill) {
+    vfill = (nc_vlen_t *) io->fill;
+    if (vfill[0].len > 0) {
+      basefill = vfill[0].p;
+      basefillsize = basesize;
+    }
+  }
+
+  /* Convert vlen elements to list items */
   for (ii=0; ii<cnt; ii++) {
     tmprxp = PROTECT(R_nc_c2r_init (&tmpio, &(vbuf[ii].p), io->ncid, basetype, -1,
                        &(vbuf[ii].len), io->rawchar, io->fitnum,
-                       io->fillsize, io->fill, io->min, io->max, io->scale, io->add));
+                       basefillsize, basefill, io->min, io->max, io->scale, io->add));
     R_nc_c2r (&tmpio);
     SET_VECTOR_ELT (io->rxp, ii, tmprxp);
     if (vbuf[ii].len > 0) {


### PR DESCRIPTION
This PR adds support for fill values in vlen types when `na.mode=5` is set for `var.put.nc` or `var.get.nc`.

The `_FillValue` attribute is required to have the same vlen type as the variable, and it must contain only a single vlen element. The first basetype value in the vlen element is used as the fill value. This is the approach used in the netcdf library, as described in
https://github.com/Unidata/netcdf-c/issues/1011#issuecomment-395585631 .