### PR TITLE
Separate PKG and R variables in configure

### DIFF
--- a/.github/workflows/check-extra.yaml
+++ b/.github/workflows/check-extra.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'devel', arch: 'base', http-user-agent: 'release', rtools: 'devel'}
+          - {os: windows-latest, r: 'devel', arch: 'base', http-user-agent: 'release', rtools: ''}
 
           # R-4.0.0 uses Rtools40 (based on msys2).
           - {os: windows-latest, r: '4.0.0', arch: '64', rtools: '40'}
@@ -43,6 +43,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          rtools-version: ${{ matrix.config.rtools }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 

--- a/.github/workflows/check-extra.yaml
+++ b/.github/workflows/check-extra.yaml
@@ -18,11 +18,13 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'devel', arch: 'base', http-user-agent: 'release'}
+          - {os: windows-latest, r: 'devel', arch: 'base', http-user-agent: 'release', rtools: 'devel'}
 
-          # use 4.1 to check with rtools40's older compiler
-          - {os: windows-latest, r: '4.1', arch: '64'}
-          - {os: windows-latest, r: '4.1', arch: '32'}
+          # R-4.0.0 uses Rtools40 (based on msys2).
+          - {os: windows-latest, r: '4.0.0', arch: '64', rtools: '40'}
+          - {os: windows-latest, r: '4.0.0', arch: '32', rtools: '40'}
+          # R>=4.2 uses Rtools42 or later (based on MXE, 64-bit only).
+          - {os: windows-latest, r: '4.2.0', arch: 'base', rtools: '42'}
 
           - {os: ubuntu-latest, r: '3.0.0', arch: 'base'}
 
@@ -55,7 +57,7 @@ jobs:
           sudo apt-get install -y libnetcdf-dev libudunits2-dev
 
       - name: Install Windows RTools40 dependencies
-        if: runner.os == 'Windows' && matrix.config.r == '4.1'
+        if: runner.os == 'Windows' && matrix.config.rtools == '40'
         run: |
           pacman -Sy
           if test "${{ matrix.config.arch }}" = 32 ; then

--- a/configure
+++ b/configure
@@ -3963,11 +3963,11 @@ printf %s "checking nc-config allows --static option... " >&6; }
        if nc-config --libs --static >/dev/null 2>&1
 then :
   nc_config_static_flag="--static"
-          { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: --static" >&5
-printf "%s\n" "--static" >&6; }
+          { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
 else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: (not available)" >&5
-printf "%s\n" "(not available)" >&6; }
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf "%s\n" "no" >&6; }
 fi
 
 fi

--- a/configure
+++ b/configure
@@ -647,6 +647,9 @@ ac_includes_default="\
 ac_header_c_list=
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
+PKG_LDFLAGS
+PKG_CPPFLAGS
+PKG_CFLAGS
 mpiexec
 has_parallel
 has_udunits
@@ -2585,11 +2588,42 @@ fi
 
 
 #-------------------------------------------------------------------------------#
+#  Get compiler/linker variables from environment                               #
+#-------------------------------------------------------------------------------#
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: Find compiler/linker variables from environment:" >&5
+printf "%s\n" "$as_me: Find compiler/linker variables from environment:" >&6;}
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking CFLAGS" >&5
+printf %s "checking CFLAGS... " >&6; }
+PKG_CFLAGS="$CFLAGS"
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${PKG_CFLAGS}" >&5
+printf "%s\n" "${PKG_CFLAGS}" >&6; }
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking CPPFLAGS" >&5
+printf %s "checking CPPFLAGS... " >&6; }
+PKG_CPPFLAGS="$CPPFLAGS"
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${PKG_CPPFLAGS}" >&5
+printf "%s\n" "${PKG_CPPFLAGS}" >&6; }
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking LDFLAGS" >&5
+printf %s "checking LDFLAGS... " >&6; }
+PKG_LDFLAGS="$LDFLAGS"
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${PKG_LDFLAGS}" >&5
+printf "%s\n" "${PKG_LDFLAGS}" >&6; }
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking LIBS" >&5
+printf %s "checking LIBS... " >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $LIBS" >&5
+printf "%s\n" "$LIBS" >&6; }
+
+
+#-------------------------------------------------------------------------------#
 #  Select compiler from R unless --with-mpicc has non-empty value               #
 #-------------------------------------------------------------------------------#
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: Selecting C compiler:" >&5
-printf "%s\n" "$as_me: Selecting C compiler:" >&6;}
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: Select C compiler:" >&5
+printf "%s\n" "$as_me: Select C compiler:" >&6;}
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking C compiler from --with-mpicc" >&5
 printf %s "checking C compiler from --with-mpicc... " >&6; }
@@ -2616,38 +2650,6 @@ printf %s "checking C compiler from R... " >&6; }
    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
 printf "%s\n" "$CC" >&6; }
 fi
-
-
-#-------------------------------------------------------------------------------#
-#  Get compiler/linker variables from environment                               #
-#-------------------------------------------------------------------------------#
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: Find compiler/linker variables from environment:" >&5
-printf "%s\n" "$as_me: Find compiler/linker variables from environment:" >&6;}
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking CFLAGS" >&5
-printf %s "checking CFLAGS... " >&6; }
-ENV_CFLAGS="$CFLAGS"
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${ENV_CFLAGS}" >&5
-printf "%s\n" "${ENV_CFLAGS}" >&6; }
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking CPPFLAGS" >&5
-printf %s "checking CPPFLAGS... " >&6; }
-ENV_CPPFLAGS="$CPPFLAGS"
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${ENV_CPPFLAGS}" >&5
-printf "%s\n" "${ENV_CPPFLAGS}" >&6; }
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking LDFLAGS" >&5
-printf %s "checking LDFLAGS... " >&6; }
-ENV_LDFLAGS="$LDFLAGS"
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${ENV_LDFLAGS}" >&5
-printf "%s\n" "${ENV_LDFLAGS}" >&6; }
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking LIBS" >&5
-printf %s "checking LIBS... " >&6; }
-ENV_LIBS="$LIBS"
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${ENV_LIBS}" >&5
-printf "%s\n" "${ENV_LIBS}" >&6; }
 
 
 #-------------------------------------------------------------------------------#
@@ -2679,39 +2681,14 @@ printf "%s\n" "${R_LDFLAGS}" >&6; }
 
 
 #-------------------------------------------------------------------------------#
-#  Append R compiler/linker variables to environment                            #
-#-------------------------------------------------------------------------------#
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: Append R compiler/linker variables to environment:" >&5
-printf "%s\n" "$as_me: Append R compiler/linker variables to environment:" >&6;}
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking CFLAGS" >&5
-printf %s "checking CFLAGS... " >&6; }
-CFLAGS="${ENV_CFLAGS} ${R_CFLAGS}"
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CFLAGS" >&5
-printf "%s\n" "$CFLAGS" >&6; }
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking CPPFLAGS" >&5
-printf %s "checking CPPFLAGS... " >&6; }
-CPPFLAGS="${ENV_CPPFLAGS} ${R_CPPFLAGS}"
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CPPFLAGS" >&5
-printf "%s\n" "$CPPFLAGS" >&6; }
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking LDFLAGS" >&5
-printf %s "checking LDFLAGS... " >&6; }
-LDFLAGS="${ENV_LDFLAGS} ${R_LDFLAGS}"
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $LDFLAGS" >&5
-printf "%s\n" "$LDFLAGS" >&6; }
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking LIBS" >&5
-printf %s "checking LIBS... " >&6; }
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $LIBS" >&5
-printf "%s\n" "$LIBS" >&6; }
-
-
-#-------------------------------------------------------------------------------#
 #  Identify OS                                                                  #
 #-------------------------------------------------------------------------------#
+
+# Initial compiler test with CC found earlier and compiler flags from R.
+# Original variable contents were copied to PKG_ variables earlier.
+CFLAGS="${R_CFLAGS}"
+CPPFLAGS="${R_CPPFLAGS}"
+LDFLAGS="${R_LDFLAGS}"
 
 
 
@@ -3948,18 +3925,18 @@ fi
 if test "x${have_nc_config}" = xyes
 then :
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Check compiler from nc-config:" >&5
-printf "%s\n" "$as_me: Check compiler from nc-config:" >&6;}
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Check compiler/linker variables from nc-config:" >&5
+printf "%s\n" "$as_me: Check compiler/linker variables from nc-config:" >&6;}
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking PKG_CC" >&5
-printf %s "checking PKG_CC... " >&6; }
-    PKG_CC=`nc-config --cc`
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${PKG_CC}" >&5
-printf "%s\n" "${PKG_CC}" >&6; }
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking NC_CC" >&5
+printf %s "checking NC_CC... " >&6; }
+    NC_CC=`nc-config --cc`
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${NC_CC}" >&5
+printf "%s\n" "${NC_CC}" >&6; }
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking PKG_CC matches selected C compiler" >&5
-printf %s "checking PKG_CC matches selected C compiler... " >&6; }
-    if test "$CC" != "${PKG_CC}"
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking NC_CC matches selected C compiler" >&5
+printf %s "checking NC_CC matches selected C compiler... " >&6; }
+    if test "$CC" != "${NC_CC}"
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no ... specify --with-mpicc if needed" >&5
 printf "%s\n" "no ... specify --with-mpicc if needed" >&6; }
@@ -3968,15 +3945,11 @@ else $as_nop
 printf "%s\n" "yes" >&6; }
 fi
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Prepend compiler/linker variables from nc-config:" >&5
-printf "%s\n" "$as_me: Prepend compiler/linker variables from nc-config:" >&6;}
-
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking CFLAGS" >&5
-printf %s "checking CFLAGS... " >&6; }
-    PKG_CFLAGS=`nc-config --cflags`
-    CFLAGS="${PKG_CFLAGS} $CFLAGS"
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CFLAGS" >&5
-printf "%s\n" "$CFLAGS" >&6; }
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking nc-config --cflags" >&5
+printf %s "checking nc-config --cflags... " >&6; }
+    NC_CFLAGS=`nc-config --cflags`
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${NC_CFLAGS}" >&5
+printf "%s\n" "${NC_CFLAGS}" >&6; }
 
     if test "x${with_nc_config_static}" = xyes
 then :
@@ -3987,24 +3960,35 @@ else $as_nop
        nc_config_static_label=""
 
 fi
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking LIBS ${nc_config_static_label}" >&5
-printf %s "checking LIBS ${nc_config_static_label}... " >&6; }
-    PKG_LIBS=`nc-config ${nc_config_static_flag} --libs`
-    LIBS="${PKG_LIBS} $LIBS"
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $LIBS" >&5
-printf "%s\n" "$LIBS" >&6; }
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking nc-config --libs ${nc_config_static_flag}" >&5
+printf %s "checking nc-config --libs ${nc_config_static_flag}... " >&6; }
+    NC_LIBS=`nc-config --libs ${nc_config_static_flag}`
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${NC_LIBS}" >&5
+printf "%s\n" "${NC_LIBS}" >&6; }
+
+    # Prepend to PKG variables:
+    PKG_CFLAGS="${NC_CFLAGS} ${PKG_CFLAGS}"
+    LIBS="${NC_LIBS} $LIBS"
 
 
 else $as_nop
 
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Skipping nc-config" >&5
 printf "%s\n" "$as_me: Skipping nc-config" >&6;}
-    PKG_CC=
-    PKG_CFLAGS=
-    PKG_LIBS=
 
 
 fi
+
+
+#-------------------------------------------------------------------------------#
+#  Append R compiler/linker variables to PKG variables for feature tests        #
+#-------------------------------------------------------------------------------#
+
+# CC is unchanged
+CFLAGS="${PKG_CFLAGS} ${R_CFLAGS}"
+CPPFLAGS="${PKG_CPPFLAGS} ${R_CPPFLAGS}"
+LDFLAGS="${PKG_LDFLAGS} ${R_LDFLAGS}"
+# No LIBS from R
 
 
 #-------------------------------------------------------------------------------#
@@ -6189,19 +6173,22 @@ fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Final compiler and linker variables for make:
 CC=$CC
-CFLAGS=$CFLAGS
-CPPFLAGS=$CPPFLAGS
-LDFLAGS=$LDFLAGS
-LIBS=$LIBS" >&5
+PKG_CFLAGS=${PKG_CFLAGS}
+PKG_CPPFLAGS=${PKG_CPPFLAGS}
+PKG_LDFLAGS=${PKG_LDFLAGS}
+LIBS=${LIBS}" >&5
 printf "%s\n" "$as_me: Final compiler and linker variables for make:
 CC=$CC
-CFLAGS=$CFLAGS
-CPPFLAGS=$CPPFLAGS
-LDFLAGS=$LDFLAGS
-LIBS=$LIBS" >&6;}
+PKG_CFLAGS=${PKG_CFLAGS}
+PKG_CPPFLAGS=${PKG_CPPFLAGS}
+PKG_LDFLAGS=${PKG_LDFLAGS}
+LIBS=${LIBS}" >&6;}
 
-# The above are substituted automatically in output files.
-# DEFS is also substituted, but it cannot be displayed in configure.
+
+
+
+
+# CC and LIBS are substituted automatically.
 
 
 #-------------------------------------------------------------------------------#

--- a/configure
+++ b/configure
@@ -1337,7 +1337,8 @@ Optional Packages:
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-mpicc            command for C compiler from MPI, otherwise C
                           compiler from R is used
-  --with-nc-config        get compiler options from nc-config (default)
+  --with-nc-config        get compiler options from nc-config (default except
+                          on Windows)
   --with-nc-config-static use static libraries from nc-config (default on
                           Windows & macOS)
   --with-mpiexec          command to run small parallel MPI tests after
@@ -3832,23 +3833,26 @@ printf "%s\n" "$as_me: Operating system is $platform" >&6;}
 #  Prepend compiler/linker variables from nc-config (if specified)              #
 #-------------------------------------------------------------------------------#
 
+# Enable nc-config by default,
+# except on Windows which currently needs special handling (see later):
 
 # Check whether --with-nc-config was given.
 if test ${with_nc_config+y}
 then :
   withval=$with_nc_config;
 else $as_nop
-  with_nc_config=yes
+  with_nc_config=unset
 fi
 
 
-# nc-config is currently broken on Windows, so disable it:
-if test "x$platform" = xWindows
+if test "x${with_nc_config}" = xunset
+then :
+  if test "x$platform" = xWindows
 then :
   with_nc_config=no
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Disabling nc-config on Windows" >&5
-printf "%s\n" "$as_me: Disabling nc-config on Windows" >&6;}
-
+else $as_nop
+  with_nc_config=yes
+fi
 fi
 
 if test "x${with_nc_config}" = xyes
@@ -3951,15 +3955,23 @@ printf %s "checking nc-config --cflags... " >&6; }
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${NC_CFLAGS}" >&5
 printf "%s\n" "${NC_CFLAGS}" >&6; }
 
+    nc_config_static_flag=""
     if test "x${with_nc_config_static}" = xyes
 then :
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking nc-config allows --static option" >&5
+printf %s "checking nc-config allows --static option... " >&6; }
+       if nc-config --libs --static >/dev/null 2>&1
+then :
   nc_config_static_flag="--static"
-       nc_config_static_label=" (static)"
+          { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: --static" >&5
+printf "%s\n" "--static" >&6; }
 else $as_nop
-  nc_config_static_flag=""
-       nc_config_static_label=""
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: (not available)" >&5
+printf "%s\n" "(not available)" >&6; }
+fi
 
 fi
+
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking nc-config --libs ${nc_config_static_flag}" >&5
 printf %s "checking nc-config --libs ${nc_config_static_flag}... " >&6; }
     NC_LIBS=`nc-config --libs ${nc_config_static_flag}`

--- a/configure.ac
+++ b/configure.ac
@@ -148,20 +148,20 @@ AS_IF([test "x${have_nc_config}" = xyes],
   [
     AC_MSG_NOTICE([Check compiler from nc-config:])
 
-    AC_MSG_CHECKING([PKG_CC])
-    PKG_CC=`nc-config --cc`
-    AC_MSG_RESULT([${PKG_CC}])
+    AC_MSG_CHECKING([NC_CC])
+    NC_CC=`nc-config --cc`
+    AC_MSG_RESULT([${NC_CC}])
 
-    AC_MSG_CHECKING([PKG_CC matches selected C compiler])
-    AS_IF([test "$CC" != "${PKG_CC}"],
+    AC_MSG_CHECKING([NC_CC matches selected C compiler])
+    AS_IF([test "$CC" != "${NC_CC}"],
           [AC_MSG_RESULT([no ... specify --with-mpicc if needed])],
           [AC_MSG_RESULT([yes])])
 
     AC_MSG_NOTICE([Prepend compiler/linker variables from nc-config:])
 
     AC_MSG_CHECKING([CFLAGS])
-    PKG_CFLAGS=`nc-config --cflags`
-    CFLAGS="${PKG_CFLAGS} $CFLAGS"
+    NC_CFLAGS=`nc-config --cflags`
+    CFLAGS="${NC_CFLAGS} $CFLAGS"
     AC_MSG_RESULT([$CFLAGS])
 
     AS_IF([test "x${with_nc_config_static}" = xyes],
@@ -171,15 +171,15 @@ AS_IF([test "x${have_nc_config}" = xyes],
        nc_config_static_label=""]
     )
     AC_MSG_CHECKING([LIBS ${nc_config_static_label}])
-    PKG_LIBS=`nc-config ${nc_config_static_flag} --libs`
-    LIBS="${PKG_LIBS} $LIBS"
+    NC_LIBS=`nc-config ${nc_config_static_flag} --libs`
+    LIBS="${NC_LIBS} $LIBS"
     AC_MSG_RESULT([$LIBS])
 
   ], [
     AC_MSG_NOTICE([Skipping nc-config])
-    PKG_CC=
-    PKG_CFLAGS=
-    PKG_LIBS=
+    NC_CC=
+    NC_CFLAGS=
+    NC_LIBS=
   ]
 )
 

--- a/configure.ac
+++ b/configure.ac
@@ -145,12 +145,15 @@ AS_IF([test "x${have_nc_config}" = xyes],
     NC_CFLAGS=`nc-config --cflags`
     AC_MSG_RESULT([${NC_CFLAGS}])
 
+    nc_config_static_flag=""
     AS_IF([test "x${with_nc_config_static}" = xyes],
-      [nc_config_static_flag="--static"
-       nc_config_static_label=" (static)"],
-      [nc_config_static_flag=""
-       nc_config_static_label=""]
-    )
+      [AC_MSG_CHECKING([nc-config allows --static option])
+       AS_IF([nc-config --libs --static >/dev/null 2>&1],
+         [nc_config_static_flag="--static"
+          AC_MSG_RESULT([--static])],
+         [AC_MSG_RESULT([(not available)])])
+      ])
+
     AC_MSG_CHECKING([nc-config --libs ${nc_config_static_flag}])
     NC_LIBS=`nc-config --libs ${nc_config_static_flag}`
     AC_MSG_RESULT([${NC_LIBS}])

--- a/configure.ac
+++ b/configure.ac
@@ -150,8 +150,8 @@ AS_IF([test "x${have_nc_config}" = xyes],
       [AC_MSG_CHECKING([nc-config allows --static option])
        AS_IF([nc-config --libs --static >/dev/null 2>&1],
          [nc_config_static_flag="--static"
-          AC_MSG_RESULT([--static])],
-         [AC_MSG_RESULT([(not available)])])
+          AC_MSG_RESULT([yes])],
+         [AC_MSG_RESULT([no])])
       ])
 
     AC_MSG_CHECKING([nc-config --libs ${nc_config_static_flag}])

--- a/configure.ac
+++ b/configure.ac
@@ -11,10 +11,32 @@ AS_IF([test -z "${R_HOME}"],
 
 
 #-------------------------------------------------------------------------------#
+#  Get compiler/linker variables from environment                               #
+#-------------------------------------------------------------------------------#
+
+AC_MSG_NOTICE([Find compiler/linker variables from environment:])
+
+AC_MSG_CHECKING([CFLAGS])
+PKG_CFLAGS="$CFLAGS"
+AC_MSG_RESULT([${PKG_CFLAGS}])
+
+AC_MSG_CHECKING([CPPFLAGS])
+PKG_CPPFLAGS="$CPPFLAGS"
+AC_MSG_RESULT([${PKG_CPPFLAGS}])
+
+AC_MSG_CHECKING([LDFLAGS])
+PKG_LDFLAGS="$LDFLAGS"
+AC_MSG_RESULT([${PKG_LDFLAGS}])
+
+AC_MSG_CHECKING([LIBS])
+AC_MSG_RESULT([$LIBS])
+
+
+#-------------------------------------------------------------------------------#
 #  Select compiler from R unless --with-mpicc has non-empty value               #
 #-------------------------------------------------------------------------------#
 
-AC_MSG_NOTICE([Selecting C compiler:])
+AC_MSG_NOTICE([Select C compiler:])
 
 AC_MSG_CHECKING([C compiler from --with-mpicc])
 
@@ -31,29 +53,6 @@ AS_IF([test -z "$CC"],
    R_CC=`"${R_HOME}/bin/R" CMD config CC`
    CC="${R_CC}"
    AC_MSG_RESULT([$CC])])
-
-
-#-------------------------------------------------------------------------------#
-#  Get compiler/linker variables from environment                               #
-#-------------------------------------------------------------------------------#
-
-AC_MSG_NOTICE([Find compiler/linker variables from environment:])
-
-AC_MSG_CHECKING([CFLAGS])
-ENV_CFLAGS="$CFLAGS"
-AC_MSG_RESULT([${ENV_CFLAGS}])
-
-AC_MSG_CHECKING([CPPFLAGS])
-ENV_CPPFLAGS="$CPPFLAGS"
-AC_MSG_RESULT([${ENV_CPPFLAGS}])
-
-AC_MSG_CHECKING([LDFLAGS])
-ENV_LDFLAGS="$LDFLAGS"
-AC_MSG_RESULT([${ENV_LDFLAGS}])
-
-AC_MSG_CHECKING([LIBS])
-ENV_LIBS="$LIBS"
-AC_MSG_RESULT([${ENV_LIBS}])
 
 
 #-------------------------------------------------------------------------------#
@@ -78,30 +77,14 @@ AC_MSG_RESULT([${R_LDFLAGS}])
 
 
 #-------------------------------------------------------------------------------#
-#  Append R compiler/linker variables to environment                            #
-#-------------------------------------------------------------------------------#
-
-AC_MSG_NOTICE([Append R compiler/linker variables to environment:])
-
-AC_MSG_CHECKING([CFLAGS])
-CFLAGS="${ENV_CFLAGS} ${R_CFLAGS}"
-AC_MSG_RESULT([$CFLAGS])
-
-AC_MSG_CHECKING([CPPFLAGS])
-CPPFLAGS="${ENV_CPPFLAGS} ${R_CPPFLAGS}"
-AC_MSG_RESULT([$CPPFLAGS])
-
-AC_MSG_CHECKING([LDFLAGS])
-LDFLAGS="${ENV_LDFLAGS} ${R_LDFLAGS}"
-AC_MSG_RESULT([$LDFLAGS])
-
-AC_MSG_CHECKING([LIBS])
-AC_MSG_RESULT([$LIBS])
-
-
-#-------------------------------------------------------------------------------#
 #  Identify OS                                                                  #
 #-------------------------------------------------------------------------------#
+
+# Initial compiler test with CC found earlier and compiler flags from R.
+# Original variable contents were copied to PKG_ variables earlier.
+CFLAGS="${R_CFLAGS}"
+CPPFLAGS="${R_CPPFLAGS}"
+LDFLAGS="${R_LDFLAGS}"
 
 AC_CHECK_DECLS([_WIN32],
   [platform=Windows],
@@ -146,7 +129,7 @@ AS_IF([test "x${with_nc_config_static}" = xunset],
 
 AS_IF([test "x${have_nc_config}" = xyes],
   [
-    AC_MSG_NOTICE([Check compiler from nc-config:])
+    AC_MSG_NOTICE([Check compiler/linker variables from nc-config:])
 
     AC_MSG_CHECKING([NC_CC])
     NC_CC=`nc-config --cc`
@@ -157,12 +140,9 @@ AS_IF([test "x${have_nc_config}" = xyes],
           [AC_MSG_RESULT([no ... specify --with-mpicc if needed])],
           [AC_MSG_RESULT([yes])])
 
-    AC_MSG_NOTICE([Prepend compiler/linker variables from nc-config:])
-
-    AC_MSG_CHECKING([CFLAGS])
+    AC_MSG_CHECKING([nc-config --cflags])
     NC_CFLAGS=`nc-config --cflags`
-    CFLAGS="${NC_CFLAGS} $CFLAGS"
-    AC_MSG_RESULT([$CFLAGS])
+    AC_MSG_RESULT([${NC_CFLAGS}])
 
     AS_IF([test "x${with_nc_config_static}" = xyes],
       [nc_config_static_flag="--static"
@@ -170,18 +150,29 @@ AS_IF([test "x${have_nc_config}" = xyes],
       [nc_config_static_flag=""
        nc_config_static_label=""]
     )
-    AC_MSG_CHECKING([LIBS ${nc_config_static_label}])
-    NC_LIBS=`nc-config ${nc_config_static_flag} --libs`
+    AC_MSG_CHECKING([nc-config --libs ${nc_config_static_flag}])
+    NC_LIBS=`nc-config --libs ${nc_config_static_flag}`
+    AC_MSG_RESULT([${NC_LIBS}])
+
+    # Prepend to PKG variables:
+    PKG_CFLAGS="${NC_CFLAGS} ${PKG_CFLAGS}"
     LIBS="${NC_LIBS} $LIBS"
-    AC_MSG_RESULT([$LIBS])
 
   ], [
     AC_MSG_NOTICE([Skipping nc-config])
-    NC_CC=
-    NC_CFLAGS=
-    NC_LIBS=
   ]
 )
+
+
+#-------------------------------------------------------------------------------#
+#  Append R compiler/linker variables to PKG variables for feature tests        #
+#-------------------------------------------------------------------------------#
+
+# CC is unchanged
+CFLAGS="${PKG_CFLAGS} ${R_CFLAGS}"
+CPPFLAGS="${PKG_CPPFLAGS} ${R_CPPFLAGS}"
+LDFLAGS="${PKG_LDFLAGS} ${R_LDFLAGS}"
+# No LIBS from R
 
 
 #-------------------------------------------------------------------------------#
@@ -398,13 +389,16 @@ AC_SUBST(mpiexec)
 
 AC_MSG_NOTICE([Final compiler and linker variables for make:
 CC=$CC
-CFLAGS=$CFLAGS
-CPPFLAGS=$CPPFLAGS
-LDFLAGS=$LDFLAGS
-LIBS=$LIBS])
+PKG_CFLAGS=${PKG_CFLAGS}
+PKG_CPPFLAGS=${PKG_CPPFLAGS}
+PKG_LDFLAGS=${PKG_LDFLAGS}
+LIBS=${LIBS}])
 
-# The above are substituted automatically in output files.
-# DEFS is also substituted, but it cannot be displayed in configure.
+AC_SUBST(PKG_CFLAGS)
+AC_SUBST(PKG_CPPFLAGS)
+AC_SUBST(PKG_LDFLAGS)
+
+# CC and LIBS are substituted automatically.
 
 
 #-------------------------------------------------------------------------------#

--- a/configure.ac
+++ b/configure.ac
@@ -98,17 +98,18 @@ AC_MSG_NOTICE([Operating system is $platform])
 #  Prepend compiler/linker variables from nc-config (if specified)              #
 #-------------------------------------------------------------------------------#
 
+# Enable nc-config by default,
+# except on Windows which currently needs special handling (see later):
 AC_ARG_WITH([nc-config],
   AS_HELP_STRING([--with-nc-config],
-    [get compiler options from nc-config (default)]),
+    [get compiler options from nc-config (default except on Windows)]),
   [],
-  [with_nc_config=yes])
+  [with_nc_config=unset])
 
-# nc-config is currently broken on Windows, so disable it:
-AS_IF([test "x$platform" = xWindows],
-  [with_nc_config=no
-   AC_MSG_NOTICE([Disabling nc-config on Windows])
-  ])
+AS_IF([test "x${with_nc_config}" = xunset],
+  [AS_IF([test "x$platform" = xWindows],
+     [with_nc_config=no],
+     [with_nc_config=yes])])
 
 AS_IF([test "x${with_nc_config}" = xyes],
   [AC_CHECK_PROG(have_nc_config, nc-config, yes, no, [], [])],

--- a/src/Makefile.common.in
+++ b/src/Makefile.common.in
@@ -3,9 +3,9 @@
 # This file is included after all other makefiles by tools/make-recursive.sh
 
 CC = @CC@
-PKG_CFLAGS = @CFLAGS@
-PKG_CPPFLAGS = @DEFS@ @CPPFLAGS@
-PKG_LIBS = @LDFLAGS@ @LIBS@
+PKG_CFLAGS = @PKG_CFLAGS@
+PKG_CPPFLAGS = @DEFS@ @PKG_CPPFLAGS@
+PKG_LIBS = @PKG_LDFLAGS@ @LIBS@
 
 RNetCDF_all: $(SHLIB) symbols.rds
 


### PR DESCRIPTION
... so that PKG variables can be defined in Makefile.common, without duplicating content of other variables.

While delving into configure.ac, we fix a few other details:
* Allow nc-config to be used on Windows if explicitly requested
* Test that nc-config allows the --static option (which is not available on early 4.x versions of NetCDF).

These changes have been rescued from #124 , which was abandoned because it broke Windows builds for R<4.2.