### PR TITLE
Improve help for accessing data in groups

### DIFF
--- a/man/att.copy.nc.Rd
+++ b/man/att.copy.nc.Rd
@@ -16,7 +16,10 @@
   \item{variable.out}{ID or name of the variable in the output NetCDF dataset to which the attribute will be copied, or \code{"NC_GLOBAL"} to copy to a global attribute.}
 }
 
-\details{This function copies an attribute from one open NetCDF dataset to another. It can also be used to copy an attribute from one variable to another within the same NetCDF dataset.}
+\details{This function copies an attribute from one open NetCDF dataset to another. It can also be used to copy an attribute from one variable to another within the same NetCDF dataset.
+
+Valid attribute ID numbers range from 0 to the number of attributes minus 1. The number of attributes of a file, group, or variable can be found using the relevant inquiry function (\code{\link[RNetCDF]{file.inq.nc}}, \code{\link[RNetCDF]{grp.inq.nc}}, or \code{\link[RNetCDF]{var.inq.nc}}).
+}
 
 \references{\url{https://www.unidata.ucar.edu/software/netcdf/}}
 

--- a/man/att.delete.nc.Rd
+++ b/man/att.delete.nc.Rd
@@ -11,10 +11,13 @@
 \arguments{
   \item{ncfile}{Object of class \code{NetCDF} which points to the NetCDF dataset (as returned from \code{\link[RNetCDF]{open.nc}}).}
   \item{variable}{ID or name of the attribute's variable, or \code{"NC_GLOBAL"} for a global attribute.}
-  \item{attribute}{The name of the attribute to be deleted.}
+  \item{attribute}{The name or ID of the attribute to be deleted.}
 }
 
-\details{This function deletes a NetCDF attribute from a NetCDF dataset open for writing.}
+\details{This function deletes a NetCDF attribute from a NetCDF dataset open for writing.
+
+Valid attribute ID numbers range from 0 to the number of attributes minus 1. The number of attributes of a file, group, or variable can be found using the relevant inquiry function (\code{\link[RNetCDF]{file.inq.nc}}, \code{\link[RNetCDF]{grp.inq.nc}}, or \code{\link[RNetCDF]{var.inq.nc}}).
+}
 
 \references{\url{https://www.unidata.ucar.edu/software/netcdf/}}
 

--- a/man/att.get.nc.Rd
+++ b/man/att.get.nc.Rd
@@ -28,7 +28,10 @@
   }}
 }
 
-\value{Vector with a data type that depends on the NetCDF variable. For NetCDF variables of type \code{NC_CHAR}, the R type is either \code{character} or \code{raw}, as specified by argument \code{rawchar}. For \code{NC_STRING}, the R type is \code{character}. Numeric variables are read as double precision by default, but the smallest R type that exactly represents each external type is used if \code{fitnum} is \code{TRUE}.}
+\value{Vector with a data type that depends on the NetCDF variable. For NetCDF variables of type \code{NC_CHAR}, the R type is either \code{character} or \code{raw}, as specified by argument \code{rawchar}. For \code{NC_STRING}, the R type is \code{character}. Numeric variables are read as double precision by default, but the smallest R type that exactly represents each external type is used if \code{fitnum} is \code{TRUE}.
+
+Valid attribute ID numbers range from 0 to the number of attributes minus 1. The number of attributes of a file, group, or variable can be found using the relevant inquiry function (\code{\link[RNetCDF]{file.inq.nc}}, \code{\link[RNetCDF]{grp.inq.nc}}, or \code{\link[RNetCDF]{var.inq.nc}}).
+}
 
 \details{This function returns the value of the attribute.}
 

--- a/man/att.inq.nc.Rd
+++ b/man/att.inq.nc.Rd
@@ -24,7 +24,10 @@
   \item{length}{Length of this attribute.}
 }
 
-\details{This function returns information about a NetCDF attribute. Information about an attribute include its ID, its name, its type, and its length. In general, attributes are accessed by name rather than by their ID number because the attribute number is more volatile than the name, since it can change when other attributes of the same variable are deleted.}
+\details{This function returns information about a NetCDF attribute. Information about an attribute include its ID, its name, its type, and its length. In general, attributes are accessed by name rather than by their ID number because the attribute number is more volatile than the name, since it can change when other attributes of the same variable are deleted.
+
+Valid attribute ID numbers range from 0 to the number of attributes minus 1. The number of attributes of a file, group, or variable can be found using the relevant inquiry function (\code{\link[RNetCDF]{file.inq.nc}}, \code{\link[RNetCDF]{grp.inq.nc}}, or \code{\link[RNetCDF]{var.inq.nc}}).
+}
 
 \references{\url{https://www.unidata.ucar.edu/software/netcdf/}}
 

--- a/man/att.rename.nc.Rd
+++ b/man/att.rename.nc.Rd
@@ -15,7 +15,9 @@
   \item{newname}{The new name to be assigned to the specified attribute.}
 }
 
-\details{This function changes the name of an existing attribute in a NetCDF dataset open for writing. An attribute cannot be renamed to have the same name as another attribute of the same variable.}
+\details{This function changes the name of an existing attribute in a NetCDF dataset open for writing. An attribute cannot be renamed to have the same name as another attribute of the same variable.
+
+Valid attribute ID numbers range from 0 to the number of attributes minus 1. The number of attributes of a file, group, or variable can be found using the relevant inquiry function (\code{\link[RNetCDF]{file.inq.nc}}, \code{\link[RNetCDF]{grp.inq.nc}}, or \code{\link[RNetCDF]{var.inq.nc}}).}
 
 \references{\url{https://www.unidata.ucar.edu/software/netcdf/}}
 

--- a/man/grp.inq.nc.Rd
+++ b/man/grp.inq.nc.Rd
@@ -35,24 +35,51 @@
 \author{Pavel Michna, Milton Woods}
 
 \examples{
-##  Create a new NetCDF dataset and define two dimensions
+# Create a new NetCDF dataset:
 file1 <- tempfile("grp.inq_", fileext=".nc")
-nc <- create.nc(file1)
+nc <- create.nc(file1, format="netcdf4")
 
-dim.def.nc(nc, "station", 5)
-dim.def.nc(nc, "time", unlim=TRUE)
+# Define groups in root group.
+# (Any names can be used; hierarchical numbers are used here for clarity)
+grp11 <- grp.def.nc(nc, "group1.1")
+grp12 <- grp.def.nc(nc, "group1.2")
 
-##  Create two variables, one as coordinate variable
-var.def.nc(nc, "time", "NC_INT", "time")
-var.def.nc(nc, "temperature", "NC_DOUBLE", c(0,1))
+# Define group nested in group1.1:
+grp111 <- grp.def.nc(grp11, "group1.1.1")
 
-##  Put some attributes
-att.put.nc(nc, "NC_GLOBAL", "title", "NC_CHAR", "Data from Foo")
-att.put.nc(nc, "NC_GLOBAL", "history", "NC_CHAR", paste("Created on", date()))
+# Put some attributes in each group.
+# (We could also define dimensions, types, and variables).
+att.put.nc(nc, "NC_GLOBAL", "title", "NC_CHAR", "Group 1 (root)")
+att.put.nc(grp11, "NC_GLOBAL", "title", "NC_CHAR", "Group 1.1")
+att.put.nc(grp12, "NC_GLOBAL", "title", "NC_CHAR", "Group 1.2")
+att.put.nc(grp111, "NC_GLOBAL", "title", "NC_CHAR", "Group 1.1.1")
 
-##  Inquire about the root group
-grp.inq.nc(nc)
+## Examine contents of a group directly using its hierarchical name ...
 
+mygrp <- grp.inq.nc(nc, "/group1.1/group1.1.1")
+att.get.nc(mygrp$self, "NC_GLOBAL", "title")
+
+## Recursively examine contents of nested groups ...
+# (See also print.nc for a visual overview)
+
+get_global_atts <- function(ncid) {
+  inq <- grp.inq.nc(ncid)
+  atts <- character(inq$ngatts)
+  for (ii in seq_len(inq$ngatts)) {
+    atts[ii] <- att.get.nc(ncid, "NC_GLOBAL", ii-1)
+  }
+  ngrps <- length(inq$grps)
+  grps <- vector("list", ngrps + 1)
+  grps[[1]] <- atts
+  for (ii in seq_len(ngrps)) {
+    grps[[ii + 1]] <- get_global_atts(inq$grps[[ii]])
+  }
+  return(grps)
+}
+
+get_global_atts(nc)
+
+## Tidy up:
 close.nc(nc)
 unlink(file1)
 }


### PR DESCRIPTION
Resolves #102

This PR adds examples for `grp.inq.nc` showing how to access data in nested groups.

It also explains the valid range of attribute ID numbers in help files for `att.*.nc` functions. This information was obtained from the documentation of NetCDF C library function `nc_inq_attname`.