### PR TITLE
Use correct path for `shlib.mk`

### DIFF
--- a/tools/make-recursive.sh
+++ b/tools/make-recursive.sh
@@ -22,13 +22,13 @@ if test -n "${makevars_site}"; then
   set -- "$@" -f "${makevars_site}"
 fi
 
-# Third makefile is (win)shlib.mk from R_HOME, as used by Makevars:
+# Third makefile is (win)shlib.mk from R_SHARE_DIR, as used by Makevars:
 if test "$WINDOWS" = TRUE; then
   file=winshlib.mk
 else
   file=shlib.mk
 fi
-set -- "$@" -f "${R_HOME}/share/make/$file"
+set -- "$@" -f "${R_SHARE_DIR}/make/$file"
 
 # Fourth makefile is user Makevars (if present):
 makevars_user=`"${R_HOME}/bin/Rscript" -e 'cat(tools::makevars_user())'`


### PR DESCRIPTION
This fixes building on Arch Linux.

The `R_SHARE_DIR` is not necessarily located in `${R_HOME}/share`. For example on Arch Linux, `R_HOME=/usr/lib64/R` while `R_SHARE_DIR=/usr/share/R`, so the correct path of `shlib.mk` on Arch is `/usr/share/R/make/shlib.mk`.