### PR TITLE
Fix UBSAN warning when converting empty NC_CHAR to R string

### DIFF
--- a/.github/workflows/test-ubsan.yaml
+++ b/.github/workflows/test-ubsan.yaml
@@ -1,0 +1,57 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: UBSAN-check
+
+jobs:
+  UBSAN-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - name: Configure git
+        run: git config --global core.autocrlf false
+
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - name: Install R dependencies (not macOS)
+        if: runner.os != 'macOS'
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - name: Check RNetCDF package (not macOS)
+        if: runner.os != 'macOS'
+        uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-results: true
+        env:
+          _R_CHECK_FORCE_SUGGESTS_: true
+          CFLAGS: -g -O2 -Wall -pedantic -mtune=native -fsanitize=undefined -fno-sanitize-recover
+          LDFLAGS: -fsanitize=undefined -fno-sanitize-recover
+

--- a/src/convert.c
+++ b/src/convert.c
@@ -257,22 +257,19 @@ R_nc_char_strsxp (R_nc_buf *io)
   }
   rlen = (clen <= RNC_CHARSXP_MAXLEN) ? clen : RNC_CHARSXP_MAXLEN;
   cnt = xlength (io->rxp);
-  /* If C buffer has row length > 0, convert rows of C buffer to separate R strings,
-     otherwise return empty R strings as initialised by R_nc_allocArray */
-  if (clen > 0) {
-    for (ii=0, thisstr=io->cbuf; ii<cnt; ii++, thisstr+=clen) {
-      /* Find string length to first fill value, not exceeding row length */
-      if (hasfill) {
-	thislen = R_nc_strnlen (thisstr, fillval, rlen);
-      } else {
-	thislen = rlen;
-      }
-      /* Find string length to first null character, not exceeding thislen */
-      thislen = R_nc_strnlen (thisstr, '\0', thislen);
-      /* Convert row to R string, ensuring null termination */
-      SET_STRING_ELT (io->rxp, ii, PROTECT(mkCharLen (thisstr, thislen)));
-      UNPROTECT(1);
+  /* Convert rows of C buffer to separate R strings */
+  for (ii=0, thisstr=io->cbuf; ii<cnt; ii++, thisstr+=clen) {
+    /* Find string length to first fill value, not exceeding row length */
+    if (hasfill) {
+      thislen = R_nc_strnlen (thisstr, fillval, rlen);
+    } else {
+      thislen = rlen;
     }
+    /* Find string length to first null character, not exceeding thislen */
+    thislen = R_nc_strnlen (thisstr, '\0', thislen);
+    /* Convert row to R string, ensuring null termination */
+    SET_STRING_ELT (io->rxp, ii, PROTECT(mkCharLen (thisstr, thislen)));
+    UNPROTECT(1);
   }
 }
 

--- a/src/convert.c
+++ b/src/convert.c
@@ -257,19 +257,22 @@ R_nc_char_strsxp (R_nc_buf *io)
   }
   rlen = (clen <= RNC_CHARSXP_MAXLEN) ? clen : RNC_CHARSXP_MAXLEN;
   cnt = xlength (io->rxp);
-  /* Convert rows of C buffer to separate R strings */
-  for (ii=0, thisstr=io->cbuf; ii<cnt; ii++, thisstr+=clen) {
-    /* Find string length to first fill value, not exceeding row length */
-    if (hasfill) {
-      thislen = R_nc_strnlen (thisstr, fillval, rlen);
-    } else {
-      thislen = rlen;
+  /* If C buffer has row length > 0, convert rows of C buffer to separate R strings,
+     otherwise return empty R strings as initialised by R_nc_allocArray */
+  if (clen > 0) {
+    for (ii=0, thisstr=io->cbuf; ii<cnt; ii++, thisstr+=clen) {
+      /* Find string length to first fill value, not exceeding row length */
+      if (hasfill) {
+	thislen = R_nc_strnlen (thisstr, fillval, rlen);
+      } else {
+	thislen = rlen;
+      }
+      /* Find string length to first null character, not exceeding thislen */
+      thislen = R_nc_strnlen (thisstr, '\0', thislen);
+      /* Convert row to R string, ensuring null termination */
+      SET_STRING_ELT (io->rxp, ii, PROTECT(mkCharLen (thisstr, thislen)));
+      UNPROTECT(1);
     }
-    /* Find string length to first null character, not exceeding thislen */
-    thislen = R_nc_strnlen (thisstr, '\0', thislen);
-    /* Convert row to R string, ensuring null termination */
-    SET_STRING_ELT (io->rxp, ii, PROTECT(mkCharLen (thisstr, thislen)));
-    UNPROTECT(1);
   }
 }
 

--- a/tools/convert.m4
+++ b/tools/convert.m4
@@ -258,19 +258,22 @@ R_nc_char_strsxp (R_nc_buf *io)
   }
   rlen = (clen <= RNC_CHARSXP_MAXLEN) ? clen : RNC_CHARSXP_MAXLEN;
   cnt = xlength (io->rxp);
-  /* Convert rows of C buffer to separate R strings */
-  for (ii=0, thisstr=io->cbuf; ii<cnt; ii++, thisstr+=clen) {
-    /* Find string length to first fill value, not exceeding row length */
-    if (hasfill) {
-      thislen = R_nc_strnlen (thisstr, fillval, rlen);
-    } else {
-      thislen = rlen;
+  /* If C buffer has row length > 0, convert rows of C buffer to separate R strings,
+     otherwise return empty R strings as initialised by R_nc_allocArray */
+  if (clen > 0) {
+    for (ii=0, thisstr=io->cbuf; ii<cnt; ii++, thisstr+=clen) {
+      /* Find string length to first fill value, not exceeding row length */
+      if (hasfill) {
+	thislen = R_nc_strnlen (thisstr, fillval, rlen);
+      } else {
+	thislen = rlen;
+      }
+      /* Find string length to first null character, not exceeding thislen */
+      thislen = R_nc_strnlen (thisstr, '\0', thislen);
+      /* Convert row to R string, ensuring null termination */
+      SET_STRING_ELT (io->rxp, ii, PROTECT(mkCharLen (thisstr, thislen)));
+      UNPROTECT(1);
     }
-    /* Find string length to first null character, not exceeding thislen */
-    thislen = R_nc_strnlen (thisstr, '\0', thislen);
-    /* Convert row to R string, ensuring null termination */
-    SET_STRING_ELT (io->rxp, ii, PROTECT(mkCharLen (thisstr, thislen)));
-    UNPROTECT(1);
   }
 }
 


### PR DESCRIPTION
The original code worked correctly with gcc and clang, but UBSAN tests on CRAN reported warnings after upload of RNetCDF_2.7-1.

The warning was caused in RNetCDF-test.R in section "Read character vlen", which involved converting a vlen to R character vectors. One of the vlen members was defined to have zero length, so that the corresponding C buffer was a NULL pointer. This was correctly converted to an empty string by RNetCDF, but the code used to determine string length apparently relied on non-standard behaviour of the gcc and clang compilers.