### PR TITLE
Find R subdirectories using R.home function in make-recursive.sh

### DIFF
--- a/.github/workflows/ubuntu-native.yaml
+++ b/.github/workflows/ubuntu-native.yaml
@@ -35,8 +35,32 @@ jobs:
             sudo apt-get install -y r-base-dev
 
       - name: Check RNetCDF package
-        uses: r-lib/actions/check-r-package@v2
-        with:
-          upload-results: true
         env:
           _R_CHECK_FORCE_SUGGESTS_: false
+        run: |
+          echo ::group::Build RNetCDF
+          R CMD build .
+          echo ::endgroup::
+          echo ::group::Check RNetCDF
+          R CMD check --no-manual RNetCDF_*.*-*.tar.gz
+          echo ::endgroup::
+        shell: bash
+
+      - name: Upload check directory
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.config.os }}_r-${{ matrix.config.r }}_check
+          path: RNetCDF.Rcheck/
+          retention-days: 5
+
+      - name: Show RNetCDF install output
+        run: |
+          cat RNetCDF.Rcheck/00install.out
+        shell: bash
+
+      - name: Show RNetCDF test output
+        run: |
+          cat RNetCDF.Rcheck/tests/RNetCDF-test.Rout*
+        shell: bash
+

--- a/.github/workflows/ubuntu-native.yaml
+++ b/.github/workflows/ubuntu-native.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install R from Ubuntu
         run: |
-            sudo apt-get install -y r-base-dev
+            sudo apt-get install -y r-base-dev libnetcdf-dev libudunits2-dev
 
       - name: Check RNetCDF package
         env:

--- a/.github/workflows/ubuntu-native.yaml
+++ b/.github/workflows/ubuntu-native.yaml
@@ -30,21 +30,13 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-pandoc@v2
-
       - name: Install R from Ubuntu
         run: |
             sudo apt-get install -y r-base-dev
-
-      - name: Install R dependencies
-        uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::rcmdcheck
-          needs: check
 
       - name: Check RNetCDF package
         uses: r-lib/actions/check-r-package@v2
         with:
           upload-results: true
         env:
-          _R_CHECK_FORCE_SUGGESTS_: true
+          _R_CHECK_FORCE_SUGGESTS_: false

--- a/.github/workflows/ubuntu-native.yaml
+++ b/.github/workflows/ubuntu-native.yaml
@@ -32,6 +32,7 @@ jobs:
 
       - name: Install R from Ubuntu
         run: |
+            sudo DEBIAN_FRONTEND=noninteractive apt-get update -y -qq
             sudo apt-get install -y r-base-dev libnetcdf-dev libudunits2-dev
 
       - name: Check RNetCDF package

--- a/.github/workflows/ubuntu-native.yaml
+++ b/.github/workflows/ubuntu-native.yaml
@@ -60,8 +60,3 @@ jobs:
           cat RNetCDF.Rcheck/00install.out
         shell: bash
 
-      - name: Show RNetCDF test output
-        run: |
-          cat RNetCDF.Rcheck/tests/RNetCDF-test.Rout*
-        shell: bash
-

--- a/.github/workflows/ubuntu-native.yaml
+++ b/.github/workflows/ubuntu-native.yaml
@@ -1,0 +1,50 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: ubuntu-native
+
+jobs:
+  ubuntu-native:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,   r: 'native'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - name: Configure git
+        run: git config --global core.autocrlf false
+
+      - uses: actions/checkout@v3
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - name: Install R from Ubuntu
+        run: |
+            sudo apt-get install -y r-base-dev
+
+      - name: Install R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - name: Check RNetCDF package
+        uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-results: true
+        env:
+          _R_CHECK_FORCE_SUGGESTS_: true

--- a/.github/workflows/ubuntu-native.yaml
+++ b/.github/workflows/ubuntu-native.yaml
@@ -55,6 +55,7 @@ jobs:
           retention-days: 5
 
       - name: Show RNetCDF install output
+        if: success() || failure()
         run: |
           cat RNetCDF.Rcheck/00install.out
         shell: bash

--- a/tools/make-recursive.sh
+++ b/tools/make-recursive.sh
@@ -13,25 +13,31 @@
 
 # Store make arguments in positional parameters to handle spaces properly.
 
-# First makefile is Makeconf from R_HOME:
-set -- -f "${R_HOME}/etc/${R_ARCH}/Makeconf"
+# Find relevant sub-directories of R.
+# We assume that R executables are stored in ${R_HOME}/bin.
+R_bin="${R_HOME}/bin"
+R_etc=`"${R_bin}/Rscript" -e 'cat(R.home("etc"))'`
+R_share=`"${R_bin}/Rscript" -e 'cat(R.home("share"))'`
+
+# First makefile is Makeconf from R:
+set -- -f "${R_etc}/${R_ARCH}/Makeconf"
 
 # Second makefile is site Makevars (if present):
-makevars_site=`"${R_HOME}/bin/Rscript" -e 'cat(tools::makevars_site())'`
+makevars_site=`"${R_bin}/Rscript" -e 'cat(tools::makevars_site())'`
 if test -n "${makevars_site}"; then
   set -- "$@" -f "${makevars_site}"
 fi
 
-# Third makefile is (win)shlib.mk from R_SHARE_DIR, as used by Makevars:
+# Third makefile is (win)shlib.mk from R, as used by Makevars:
 if test "$WINDOWS" = TRUE; then
   file=winshlib.mk
 else
   file=shlib.mk
 fi
-set -- "$@" -f "${R_SHARE_DIR}/make/$file"
+set -- "$@" -f "${R_share}/make/$file"
 
 # Fourth makefile is user Makevars (if present):
-makevars_user=`"${R_HOME}/bin/Rscript" -e 'cat(tools::makevars_user())'`
+makevars_user=`"${R_bin}/Rscript" -e 'cat(tools::makevars_user())'`
 if test -n "${makevars_user}"; then
   set -- "$@" -f "${makevars_user}"
 fi

--- a/tools/make-recursive.sh
+++ b/tools/make-recursive.sh
@@ -16,8 +16,8 @@
 # Find relevant sub-directories of R.
 # We assume that R executables are stored in ${R_HOME}/bin.
 R_bin="${R_HOME}/bin"
-R_etc=`"${R_bin}/Rscript" -e 'cat(R.home("etc"))'`
-R_share=`"${R_bin}/Rscript" -e 'cat(R.home("share"))'`
+R_etc=`"${R_bin}/Rscript" -e "cat(R.home('etc'))"`
+R_share=`"${R_bin}/Rscript" -e "cat(R.home('share'))"`
 
 # First makefile is Makeconf from R:
 set -- -f "${R_etc}/${R_ARCH}/Makeconf"


### PR DESCRIPTION
PR #128 provided a solution for #129 and #130 . This PR aims to generalise the solution to handle R installations where the `etc` subdirectory is outside the `$R_HOME` directory tree. Such an installation is supported by the R configure script, although it may not occur in practice.

The solution adopted here assumes that R executables are stored in `$R_HOME/bin`. This is consistent with advice in https://cran.csiro.au/doc/manuals/r-release/R-exts.html#Configure-and-cleanup . The alternative of using R from the PATH could find a different version of R than the one intended for package installation.