### PR TITLE
Conversions fail with oneAPI compiler

### DIFF
--- a/configure
+++ b/configure
@@ -5511,11 +5511,11 @@ fi
 
 
 #-------------------------------------------------------------------------------#
-#  Find sizes of selected data types                                            #
+#  Check type sizes and language features supported by compiler                 #
 #-------------------------------------------------------------------------------#
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: Find sizes of selected data types:" >&5
-printf "%s\n" "$as_me: Find sizes of selected data types:" >&6;}
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: Check compiler type sizes and language features" >&5
+printf "%s\n" "$as_me: Check compiler type sizes and language features" >&6;}
 
 # The cast to long int works around a bug in the HP C Compiler
 # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
@@ -5615,6 +5615,56 @@ printf "%s\n" "$ac_cv_sizeof_size_t" >&6; }
 
 printf "%s\n" "#define SIZEOF_SIZE_T $ac_cv_sizeof_size_t" >>confdefs.h
 
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for C/C++ restrict keyword" >&5
+printf %s "checking for C/C++ restrict keyword... " >&6; }
+if test ${ac_cv_c_restrict+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  ac_cv_c_restrict=no
+   # Put '__restrict__' first, to avoid problems with glibc and non-GCC; see:
+   # https://lists.gnu.org/archive/html/bug-autoconf/2016-02/msg00006.html
+   # Put 'restrict' last, because C++ lacks it.
+   for ac_kw in __restrict__ __restrict _Restrict restrict; do
+     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+typedef int *int_ptr;
+	   int foo (int_ptr $ac_kw ip) { return ip[0]; }
+	   int bar (int [$ac_kw]); /* Catch GCC bug 14050.  */
+	   int bar (int ip[$ac_kw]) { return ip[0]; }
+
+int
+main (void)
+{
+int s[1];
+	   int *$ac_kw t = s;
+	   t[0] = 0;
+	   return foo (t) + bar (t);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  ac_cv_c_restrict=$ac_kw
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+     test "$ac_cv_c_restrict" != no && break
+   done
+
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_restrict" >&5
+printf "%s\n" "$ac_cv_c_restrict" >&6; }
+
+ case $ac_cv_c_restrict in
+   restrict) ;;
+   no) printf "%s\n" "#define restrict /**/" >>confdefs.h
+ ;;
+   *)  printf "%s\n" "#define restrict $ac_cv_c_restrict" >>confdefs.h
+ ;;
+ esac
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -233,14 +233,15 @@ AS_IF([test "x$platform" = xWindows], [
 
 
 #-------------------------------------------------------------------------------#
-#  Find sizes of selected data types                                            #
+#  Check type sizes and language features supported by compiler                 #
 #-------------------------------------------------------------------------------#
 
-AC_MSG_NOTICE([Find sizes of selected data types:])
+AC_MSG_NOTICE([Check compiler type sizes and language features])
 
 AC_CHECK_SIZEOF([int])
 AC_CHECK_SIZEOF([long long])
 AC_CHECK_SIZEOF([size_t])
+AC_C_RESTRICT()
 
 
 #-------------------------------------------------------------------------------#

--- a/src/convert.c
+++ b/src/convert.c
@@ -922,6 +922,8 @@ R_nc_r2c_dbl_schar (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       if ((ISNA(in[ii]))) {
         out[ii] = fillval;
+      } else if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
       } else if (((double) SCHAR_MIN <= in[ii]) && (in[ii] <= (double) SCHAR_MAX)) {
         out[ii] = in[ii];
       } else {
@@ -930,7 +932,9 @@ R_nc_r2c_dbl_schar (SEXP rv, int ndim, const size_t *xdim,
     }
   } else {
     for (ii=0; ii<cnt; ii++) {
-      if (((double) SCHAR_MIN <= in[ii]) && (in[ii] <= (double) SCHAR_MAX)) {
+      if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
+      } else if (((double) SCHAR_MIN <= in[ii]) && (in[ii] <= (double) SCHAR_MAX)) {
         out[ii] = in[ii];
       } else {
         error (nc_strerror (NC_ERANGE));
@@ -964,6 +968,8 @@ R_nc_r2c_dbl_uchar (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       if ((ISNA(in[ii]))) {
         out[ii] = fillval;
+      } else if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
       } else if (((double) 0 <= in[ii]) && (in[ii] <= (double) UCHAR_MAX)) {
         out[ii] = in[ii];
       } else {
@@ -972,7 +978,9 @@ R_nc_r2c_dbl_uchar (SEXP rv, int ndim, const size_t *xdim,
     }
   } else {
     for (ii=0; ii<cnt; ii++) {
-      if (((double) 0 <= in[ii]) && (in[ii] <= (double) UCHAR_MAX)) {
+      if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
+      } else if (((double) 0 <= in[ii]) && (in[ii] <= (double) UCHAR_MAX)) {
         out[ii] = in[ii];
       } else {
         error (nc_strerror (NC_ERANGE));
@@ -1006,6 +1014,8 @@ R_nc_r2c_dbl_short (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       if ((ISNA(in[ii]))) {
         out[ii] = fillval;
+      } else if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
       } else if (((double) SHRT_MIN <= in[ii]) && (in[ii] <= (double) SHRT_MAX)) {
         out[ii] = in[ii];
       } else {
@@ -1014,7 +1024,9 @@ R_nc_r2c_dbl_short (SEXP rv, int ndim, const size_t *xdim,
     }
   } else {
     for (ii=0; ii<cnt; ii++) {
-      if (((double) SHRT_MIN <= in[ii]) && (in[ii] <= (double) SHRT_MAX)) {
+      if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
+      } else if (((double) SHRT_MIN <= in[ii]) && (in[ii] <= (double) SHRT_MAX)) {
         out[ii] = in[ii];
       } else {
         error (nc_strerror (NC_ERANGE));
@@ -1048,6 +1060,8 @@ R_nc_r2c_dbl_ushort (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       if ((ISNA(in[ii]))) {
         out[ii] = fillval;
+      } else if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
       } else if (((double) 0 <= in[ii]) && (in[ii] <= (double) USHRT_MAX)) {
         out[ii] = in[ii];
       } else {
@@ -1056,7 +1070,9 @@ R_nc_r2c_dbl_ushort (SEXP rv, int ndim, const size_t *xdim,
     }
   } else {
     for (ii=0; ii<cnt; ii++) {
-      if (((double) 0 <= in[ii]) && (in[ii] <= (double) USHRT_MAX)) {
+      if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
+      } else if (((double) 0 <= in[ii]) && (in[ii] <= (double) USHRT_MAX)) {
         out[ii] = in[ii];
       } else {
         error (nc_strerror (NC_ERANGE));
@@ -1090,6 +1106,8 @@ R_nc_r2c_dbl_int (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       if ((ISNA(in[ii]))) {
         out[ii] = fillval;
+      } else if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
       } else if (((double) INT_MIN <= in[ii]) && (in[ii] <= (double) INT_MAX)) {
         out[ii] = in[ii];
       } else {
@@ -1098,7 +1116,9 @@ R_nc_r2c_dbl_int (SEXP rv, int ndim, const size_t *xdim,
     }
   } else {
     for (ii=0; ii<cnt; ii++) {
-      if (((double) INT_MIN <= in[ii]) && (in[ii] <= (double) INT_MAX)) {
+      if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
+      } else if (((double) INT_MIN <= in[ii]) && (in[ii] <= (double) INT_MAX)) {
         out[ii] = in[ii];
       } else {
         error (nc_strerror (NC_ERANGE));
@@ -1132,6 +1152,8 @@ R_nc_r2c_dbl_uint (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       if ((ISNA(in[ii]))) {
         out[ii] = fillval;
+      } else if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
       } else if (((double) 0 <= in[ii]) && (in[ii] <= (double) UINT_MAX)) {
         out[ii] = in[ii];
       } else {
@@ -1140,7 +1162,9 @@ R_nc_r2c_dbl_uint (SEXP rv, int ndim, const size_t *xdim,
     }
   } else {
     for (ii=0; ii<cnt; ii++) {
-      if (((double) 0 <= in[ii]) && (in[ii] <= (double) UINT_MAX)) {
+      if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
+      } else if (((double) 0 <= in[ii]) && (in[ii] <= (double) UINT_MAX)) {
         out[ii] = in[ii];
       } else {
         error (nc_strerror (NC_ERANGE));
@@ -1174,6 +1198,8 @@ R_nc_r2c_dbl_ll (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       if ((ISNA(in[ii]))) {
         out[ii] = fillval;
+      } else if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
       } else if (((double) LLONG_MIN_DBL <= in[ii]) && (in[ii] <= (double) LLONG_MAX_DBL)) {
         out[ii] = in[ii];
       } else {
@@ -1182,7 +1208,9 @@ R_nc_r2c_dbl_ll (SEXP rv, int ndim, const size_t *xdim,
     }
   } else {
     for (ii=0; ii<cnt; ii++) {
-      if (((double) LLONG_MIN_DBL <= in[ii]) && (in[ii] <= (double) LLONG_MAX_DBL)) {
+      if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
+      } else if (((double) LLONG_MIN_DBL <= in[ii]) && (in[ii] <= (double) LLONG_MAX_DBL)) {
         out[ii] = in[ii];
       } else {
         error (nc_strerror (NC_ERANGE));
@@ -1216,6 +1244,8 @@ R_nc_r2c_dbl_ull (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       if ((ISNA(in[ii]))) {
         out[ii] = fillval;
+      } else if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
       } else if (((double) 0 <= in[ii]) && (in[ii] <= (double) ULLONG_MAX_DBL)) {
         out[ii] = in[ii];
       } else {
@@ -1224,7 +1254,9 @@ R_nc_r2c_dbl_ull (SEXP rv, int ndim, const size_t *xdim,
     }
   } else {
     for (ii=0; ii<cnt; ii++) {
-      if (((double) 0 <= in[ii]) && (in[ii] <= (double) ULLONG_MAX_DBL)) {
+      if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
+      } else if (((double) 0 <= in[ii]) && (in[ii] <= (double) ULLONG_MAX_DBL)) {
         out[ii] = in[ii];
       } else {
         error (nc_strerror (NC_ERANGE));
@@ -1258,7 +1290,9 @@ R_nc_r2c_dbl_float (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       if ((ISNA(in[ii]))) {
         out[ii] = fillval;
-      } else if ((!R_FINITE(in[ii])) || (((double) -FLT_MAX <= in[ii]) && (in[ii] <= (double) FLT_MAX))) {
+      } else if (!R_FINITE(in[ii])) {
+        out[ii] = in[ii];
+      } else if (((double) -FLT_MAX <= in[ii]) && (in[ii] <= (double) FLT_MAX)) {
         out[ii] = in[ii];
       } else {
         error (nc_strerror (NC_ERANGE));
@@ -1266,7 +1300,9 @@ R_nc_r2c_dbl_float (SEXP rv, int ndim, const size_t *xdim,
     }
   } else {
     for (ii=0; ii<cnt; ii++) {
-      if ((!R_FINITE(in[ii])) || (((double) -FLT_MAX <= in[ii]) && (in[ii] <= (double) FLT_MAX))) {
+      if (!R_FINITE(in[ii])) {
+        out[ii] = in[ii];
+      } else if (((double) -FLT_MAX <= in[ii]) && (in[ii] <= (double) FLT_MAX)) {
         out[ii] = in[ii];
       } else {
         error (nc_strerror (NC_ERANGE));
@@ -1344,6 +1380,8 @@ R_nc_r2c_dbl_size (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       if ((ISNA(in[ii]))) {
         out[ii] = fillval;
+      } else if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
       } else if (((double) 0 <= in[ii]) && (in[ii] <= (double) SIZE_MAX_DBL)) {
         out[ii] = in[ii];
       } else {
@@ -1352,7 +1390,9 @@ R_nc_r2c_dbl_size (SEXP rv, int ndim, const size_t *xdim,
     }
   } else {
     for (ii=0; ii<cnt; ii++) {
-      if (((double) 0 <= in[ii]) && (in[ii] <= (double) SIZE_MAX_DBL)) {
+      if (!R_FINITE(in[ii])) {
+        error (nc_strerror (NC_ERANGE));
+      } else if (((double) 0 <= in[ii]) && (in[ii] <= (double) SIZE_MAX_DBL)) {
         out[ii] = in[ii];
       } else {
         error (nc_strerror (NC_ERANGE));

--- a/src/convert.c
+++ b/src/convert.c
@@ -1947,7 +1947,9 @@ R_nc_r2c_pack_int_schar (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) SCHAR_MIN <= dpack) && (dpack <= (double) SCHAR_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) SCHAR_MIN <= dpack) && (dpack <= (double) SCHAR_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -1958,7 +1960,9 @@ R_nc_r2c_pack_int_schar (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) SCHAR_MIN <= dpack) && (dpack <= (double) SCHAR_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) SCHAR_MIN <= dpack) && (dpack <= (double) SCHAR_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2003,7 +2007,9 @@ R_nc_r2c_pack_int_uchar (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) UCHAR_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) UCHAR_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2014,7 +2020,9 @@ R_nc_r2c_pack_int_uchar (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) UCHAR_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) UCHAR_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2059,7 +2067,9 @@ R_nc_r2c_pack_int_short (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) SHRT_MIN <= dpack) && (dpack <= (double) SHRT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) SHRT_MIN <= dpack) && (dpack <= (double) SHRT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2070,7 +2080,9 @@ R_nc_r2c_pack_int_short (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) SHRT_MIN <= dpack) && (dpack <= (double) SHRT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) SHRT_MIN <= dpack) && (dpack <= (double) SHRT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2115,7 +2127,9 @@ R_nc_r2c_pack_int_ushort (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) USHRT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) USHRT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2126,7 +2140,9 @@ R_nc_r2c_pack_int_ushort (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) USHRT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) USHRT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2171,7 +2187,9 @@ R_nc_r2c_pack_int_int (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) INT_MIN <= dpack) && (dpack <= (double) INT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) INT_MIN <= dpack) && (dpack <= (double) INT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2182,7 +2200,9 @@ R_nc_r2c_pack_int_int (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) INT_MIN <= dpack) && (dpack <= (double) INT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) INT_MIN <= dpack) && (dpack <= (double) INT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2227,7 +2247,9 @@ R_nc_r2c_pack_int_uint (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) UINT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) UINT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2238,7 +2260,9 @@ R_nc_r2c_pack_int_uint (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) UINT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) UINT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2283,7 +2307,9 @@ R_nc_r2c_pack_int_ll (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) LLONG_MIN_DBL  <= dpack) && (dpack <= (double) LLONG_MAX_DBL)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) LLONG_MIN_DBL  <= dpack) && (dpack <= (double) LLONG_MAX_DBL)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2294,7 +2320,9 @@ R_nc_r2c_pack_int_ll (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) LLONG_MIN_DBL  <= dpack) && (dpack <= (double) LLONG_MAX_DBL)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) LLONG_MIN_DBL  <= dpack) && (dpack <= (double) LLONG_MAX_DBL)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2339,7 +2367,9 @@ R_nc_r2c_pack_int_ull (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) ULLONG_MAX_DBL)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) ULLONG_MAX_DBL)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2350,7 +2380,9 @@ R_nc_r2c_pack_int_ull (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) ULLONG_MAX_DBL)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) ULLONG_MAX_DBL)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2395,7 +2427,9 @@ R_nc_r2c_pack_int_float (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if ((!R_FINITE(dpack)) || (((double) -FLT_MAX <= dpack) && (dpack <= (double) FLT_MAX))) {
+        if (!R_FINITE(dpack)) {
+          out[ii] = dpack;
+        } else if (((double) -FLT_MAX <= dpack) && (dpack <= (double) FLT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2406,7 +2440,9 @@ R_nc_r2c_pack_int_float (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if ((!R_FINITE(dpack)) || (((double) -FLT_MAX <= dpack) && (dpack <= (double) FLT_MAX))) {
+        if (!R_FINITE(dpack)) {
+          out[ii] = dpack;
+        } else if (((double) -FLT_MAX <= dpack) && (dpack <= (double) FLT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2499,7 +2535,9 @@ R_nc_r2c_pack_dbl_schar (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) SCHAR_MIN <= dpack) && (dpack <= (double) SCHAR_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) SCHAR_MIN <= dpack) && (dpack <= (double) SCHAR_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2510,7 +2548,9 @@ R_nc_r2c_pack_dbl_schar (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) SCHAR_MIN <= dpack) && (dpack <= (double) SCHAR_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) SCHAR_MIN <= dpack) && (dpack <= (double) SCHAR_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2555,7 +2595,9 @@ R_nc_r2c_pack_dbl_uchar (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) UCHAR_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) UCHAR_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2566,7 +2608,9 @@ R_nc_r2c_pack_dbl_uchar (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) UCHAR_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) UCHAR_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2611,7 +2655,9 @@ R_nc_r2c_pack_dbl_short (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) SHRT_MIN <= dpack) && (dpack <= (double) SHRT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) SHRT_MIN <= dpack) && (dpack <= (double) SHRT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2622,7 +2668,9 @@ R_nc_r2c_pack_dbl_short (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) SHRT_MIN <= dpack) && (dpack <= (double) SHRT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) SHRT_MIN <= dpack) && (dpack <= (double) SHRT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2667,7 +2715,9 @@ R_nc_r2c_pack_dbl_ushort (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) USHRT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) USHRT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2678,7 +2728,9 @@ R_nc_r2c_pack_dbl_ushort (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) USHRT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) USHRT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2723,7 +2775,9 @@ R_nc_r2c_pack_dbl_int (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) INT_MIN <= dpack) && (dpack <= (double) INT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) INT_MIN <= dpack) && (dpack <= (double) INT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2734,7 +2788,9 @@ R_nc_r2c_pack_dbl_int (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) INT_MIN <= dpack) && (dpack <= (double) INT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) INT_MIN <= dpack) && (dpack <= (double) INT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2779,7 +2835,9 @@ R_nc_r2c_pack_dbl_uint (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) UINT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) UINT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2790,7 +2848,9 @@ R_nc_r2c_pack_dbl_uint (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) UINT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) UINT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2835,7 +2895,9 @@ R_nc_r2c_pack_dbl_ll (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) LLONG_MIN_DBL <= dpack) && (dpack <= (double) LLONG_MAX_DBL)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) LLONG_MIN_DBL <= dpack) && (dpack <= (double) LLONG_MAX_DBL)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2846,7 +2908,9 @@ R_nc_r2c_pack_dbl_ll (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) LLONG_MIN_DBL <= dpack) && (dpack <= (double) LLONG_MAX_DBL)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) LLONG_MIN_DBL <= dpack) && (dpack <= (double) LLONG_MAX_DBL)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2891,7 +2955,9 @@ R_nc_r2c_pack_dbl_ull (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) ULLONG_MAX_DBL)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) ULLONG_MAX_DBL)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2902,7 +2968,9 @@ R_nc_r2c_pack_dbl_ull (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) ULLONG_MAX_DBL)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) ULLONG_MAX_DBL)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2947,7 +3015,9 @@ R_nc_r2c_pack_dbl_float (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if ((!R_FINITE(dpack)) || (((double) -FLT_MAX <= dpack) && (dpack <= (double) FLT_MAX))) {
+        if (!R_FINITE(dpack)) {
+          out[ii] = dpack;
+        } else if (((double) -FLT_MAX <= dpack) && (dpack <= (double) FLT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -2958,7 +3028,9 @@ R_nc_r2c_pack_dbl_float (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if ((!R_FINITE(dpack)) || (((double) -FLT_MAX <= dpack) && (dpack <= (double) FLT_MAX))) {
+        if (!R_FINITE(dpack)) {
+          out[ii] = dpack;
+        } else if (((double) -FLT_MAX <= dpack) && (dpack <= (double) FLT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3057,7 +3129,9 @@ R_nc_r2c_pack_bit64_schar (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) SCHAR_MIN <= dpack) && (dpack <= (double) SCHAR_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) SCHAR_MIN <= dpack) && (dpack <= (double) SCHAR_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3068,7 +3142,9 @@ R_nc_r2c_pack_bit64_schar (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) SCHAR_MIN <= dpack) && (dpack <= (double) SCHAR_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) SCHAR_MIN <= dpack) && (dpack <= (double) SCHAR_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3113,7 +3189,9 @@ R_nc_r2c_pack_bit64_uchar (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) UCHAR_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) UCHAR_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3124,7 +3202,9 @@ R_nc_r2c_pack_bit64_uchar (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) UCHAR_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) UCHAR_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3169,7 +3249,9 @@ R_nc_r2c_pack_bit64_short (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) SHRT_MIN <= dpack) && (dpack <= (double) SHRT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) SHRT_MIN <= dpack) && (dpack <= (double) SHRT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3180,7 +3262,9 @@ R_nc_r2c_pack_bit64_short (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) SHRT_MIN <= dpack) && (dpack <= (double) SHRT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) SHRT_MIN <= dpack) && (dpack <= (double) SHRT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3225,7 +3309,9 @@ R_nc_r2c_pack_bit64_ushort (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) USHRT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) USHRT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3236,7 +3322,9 @@ R_nc_r2c_pack_bit64_ushort (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) USHRT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) USHRT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3281,7 +3369,9 @@ R_nc_r2c_pack_bit64_int (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) INT_MIN <= dpack) && (dpack <= (double) INT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) INT_MIN <= dpack) && (dpack <= (double) INT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3292,7 +3382,9 @@ R_nc_r2c_pack_bit64_int (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) INT_MIN <= dpack) && (dpack <= (double) INT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) INT_MIN <= dpack) && (dpack <= (double) INT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3337,7 +3429,9 @@ R_nc_r2c_pack_bit64_uint (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) UINT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) UINT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3348,7 +3442,9 @@ R_nc_r2c_pack_bit64_uint (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) UINT_MAX)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) UINT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3393,7 +3489,9 @@ R_nc_r2c_pack_bit64_ll (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) LLONG_MIN_DBL <= dpack) && (dpack <= (double) LLONG_MAX_DBL)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) LLONG_MIN_DBL <= dpack) && (dpack <= (double) LLONG_MAX_DBL)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3404,7 +3502,9 @@ R_nc_r2c_pack_bit64_ll (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) LLONG_MIN_DBL <= dpack) && (dpack <= (double) LLONG_MAX_DBL)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) LLONG_MIN_DBL <= dpack) && (dpack <= (double) LLONG_MAX_DBL)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3449,7 +3549,9 @@ R_nc_r2c_pack_bit64_ull (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) ULLONG_MAX_DBL)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) ULLONG_MAX_DBL)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3460,7 +3562,9 @@ R_nc_r2c_pack_bit64_ull (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if (((double) 0 <= dpack) && (dpack <= (double) ULLONG_MAX_DBL)) {
+        if (!R_FINITE(dpack)) {
+          error (nc_strerror (NC_ERANGE));
+        } else if (((double) 0 <= dpack) && (dpack <= (double) ULLONG_MAX_DBL)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3505,7 +3609,9 @@ R_nc_r2c_pack_bit64_float (SEXP rv, int ndim, const size_t *xdim,
         out[ii] = fillval;
       } else {
         dpack = round((in[ii] - offset) / factor);
-        if ((!R_FINITE(dpack)) || (((double) -FLT_MAX <= dpack) && (dpack <= (double) FLT_MAX))) {
+        if (!R_FINITE(dpack)) {
+          out[ii] = dpack;
+        } else if (((double) -FLT_MAX <= dpack) && (dpack <= (double) FLT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));
@@ -3516,7 +3622,9 @@ R_nc_r2c_pack_bit64_float (SEXP rv, int ndim, const size_t *xdim,
     for (ii=0; ii<cnt; ii++) {
       {
         dpack = round((in[ii] - offset) / factor);
-        if ((!R_FINITE(dpack)) || (((double) -FLT_MAX <= dpack) && (dpack <= (double) FLT_MAX))) {
+        if (!R_FINITE(dpack)) {
+          out[ii] = dpack;
+        } else if (((double) -FLT_MAX <= dpack) && (dpack <= (double) FLT_MAX)) {
           out[ii] = dpack;
         } else {
           error (nc_strerror (NC_ERANGE));

--- a/src/convert.h
+++ b/src/convert.h
@@ -58,12 +58,12 @@ R_nc_allocArray (SEXPTYPE type, int ndims, const size_t *ccount);
    Other functions should not access members directly. */
 typedef struct {
   SEXP rxp;
-  void *cbuf, *rbuf;
+  void *restrict cbuf, *restrict rbuf;
   nc_type xtype;
   int ncid, ndim, rawchar, fitnum;
-  size_t *xdim, fillsize;
-  void *fill, *min, *max;
-  double *scale, *add;
+  size_t *restrict xdim, fillsize;
+  void *restrict fill, *restrict min, *restrict max;
+  double *restrict scale, *restrict add;
   } R_nc_buf;
 
 

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -732,11 +732,12 @@ for (format in c("classic","offset64","data64","classic4","netcdf4")) {
         cat("Writing bit64 data with missing values and packing ...")
         y <- try(var.put.nc(nc, paste(numtype,"pack64",namode,sep="_"), mypack64, pack=TRUE, na.mode=namode), silent=TRUE)
         tally <- testfun(inherits(y, "try-error"), napack64fail, tally)
+
+        cat("Writing integer64 with non-finite packing ...")
+        y <- try(var.put.nc(nc, paste(numtype,"packinf64",namode,sep="_"), mypack64, pack=TRUE, na.mode=namode), silent=TRUE)
+        tally <- testfun(inherits(y, "try-error"), inffail, tally)
       }
 
-      cat("Writing integer64 with non-finite packing ...")
-      y <- try(var.put.nc(nc, paste(numtype,"packinf64",namode,sep="_"), mypack64, pack=TRUE, na.mode=namode), silent=TRUE)
-      tally <- testfun(inherits(y, "try-error"), inffail, tally)
     }
   }
 


### PR DESCRIPTION
CRAN reports failures for RNetCDF_2.7-1 tests when the package is checked with oneAPI 2023.x compilers.

After installing R with the oneAPI compilers on RHEL8 (as described in https://cran.r-project.org/doc/manuals/r-devel/R-admin.html#Intel-compilers), my experiments with compiler flags showed that tests worked correctly with the following options in `~/.R/Makevars`:

```
CFLAGS = -O3 -no-ansi-alias -fhonor-nan-compares
```

Although it would be possible to insert these compiler flags in `configure.ac`, this PR aims to fix the underlying problems in `src/convert.c` (which is generated from `tools/convert.m4`).