### PR TITLE
Fix linking with an upcoming version of Rtools on Windows where netcdf needs curl.

### DIFF
--- a/configure.win
+++ b/configure.win
@@ -1,3 +1,8 @@
 #!/bin/sh
 
-. ./configure
+if [ X"`pkg-config --version 2>/dev/null`" != X ] ; then
+  ./configure LIBS="`pkg-config --libs netcdf`"
+else
+  ./configure
+fi
+  


### PR DESCRIPTION
This fixes the package to build with an upcoming version of Rtools on Windows. Netcdf now needs also libcurl, but the configure file doesn't assume that, so the patch resorts to pkg-config. Tested also with Rtools43 and Rtools42.