### PR TITLE
just use as.character() & let S3 dispatch work

### DIFF
--- a/R/RNetCDF.R
+++ b/R/RNetCDF.R
@@ -323,12 +323,8 @@ print_att <- function(grp, attinfo, indent, varinfo=NULL) {
     atttypestr <- attinfo$type
     attval <- att.get.nc(grp, varid, attinfo$id,
                          fitnum=requireNamespace("bit64", quietly=TRUE))
-    if (inherits(attval, "integer64")) {
-      attvalchar <- bit64::as.character.integer64(attval)
-    } else {
-      attvalchar <- as.character(attval)
-    }
-    attvalstr <- paste(attvalchar, collapse=", ", sep="")
+    attvalchar <- as.character(attval)
+    attvalstr <- toString(attvalchar)
   }
   tab <- "\t"
   cat(indent, tab, tab, atttypestr, " ",


### PR DESCRIPTION
Closes #148

`att.get.nc()` already checks `requireNamespace("bit64")` if `inherits(attval, "integer64")` and errors if not.

So upon return from `att.get.nc()`, we know that `isNamespaceLoaded("bit64")`, and therefore that the S3 method `as.character.integer64` will dispatch correctly.