### PR TITLE
Update github actions from v3 to v4

### DIFF
--- a/.github/workflows/check-extra.yaml
+++ b/.github/workflows/check-extra.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Configure git
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload check directory
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.config.os }}_r-${{ matrix.config.r }}-${{ matrix.config.arch }}_check
           path: RNetCDF.Rcheck/

--- a/.github/workflows/check-linux-mpi.yaml
+++ b/.github/workflows/check-linux-mpi.yaml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload check directory
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.config.os }}_r-${{ matrix.config.r }}_${{ matrix.config.mpi }}
           path: RNetCDF.Rcheck/

--- a/.github/workflows/check-nc-versions.yaml
+++ b/.github/workflows/check-nc-versions.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure git
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: git
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Restore system dependencies
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: opt
           key: ${{ runner.os }}_ncdf-${{ matrix.config.ncdf }}_hdf5-${{ matrix.config.hdf5 }}_udunits-${{ matrix.config.udunits }}

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Configure git
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-test-failures
           path: ${{ runner.temp }}/package

--- a/.github/workflows/test-rchk.yaml.disabled
+++ b/.github/workflows/test-rchk.yaml.disabled
@@ -17,7 +17,7 @@ jobs:
       image: rhub/ubuntu-rchk
       options: --user=root
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: r-lib/actions/run-rchk@v2
       with:
         setup-only: true

--- a/.github/workflows/test-ubsan.yaml
+++ b/.github/workflows/test-ubsan.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Configure git
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/ubuntu-native.yaml
+++ b/.github/workflows/ubuntu-native.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Configure git
         run: git config --global core.autocrlf false
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install R from Ubuntu
         run: |
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload check directory
         if: success() || failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.config.os }}_r-${{ matrix.config.r }}_check
           path: RNetCDF.Rcheck/


### PR DESCRIPTION
Github has deprecated v3 of the artifact action, so upgrade to v4 is required. To avoid problems later, we can update the checkout and cache actions as well.