### PR TITLE
Avoid calls to non-API entry points in R

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -6901,7 +6901,8 @@ R_nc_enum_factor (R_nc_buf *io)
   /* Create a hashed environment for value-index pairs.
      Members inherit PROTECTion from the env.
    */
-  env = PROTECT(R_NewEnv(R_BaseEnv, 1, 29));
+  cmd = PROTECT(lang1 (install ("new.env")));
+  env = PROTECT(eval (cmd, R_BaseEnv));
 
   /* Read values and names of netcdf enum members.
      Store names as R factor levels.

--- a/src/convert.c
+++ b/src/convert.c
@@ -6942,7 +6942,7 @@ R_nc_enum_factor (R_nc_buf *io)
   any_undef = 0;
   for (ifac=0, inval=io->cbuf; ifac<nfac; ifac++, inval+=size) {
     symbol = PROTECT(R_nc_char_symbol (inval, size, work));
-    index = findVarInFrame3 (env, symbol, TRUE);
+    index = findVar (symbol, env);
     UNPROTECT(1);
     if (index == R_UnboundValue) {
       /* Convert undefined enum values to NA,

--- a/src/convert.c
+++ b/src/convert.c
@@ -6901,8 +6901,7 @@ R_nc_enum_factor (R_nc_buf *io)
   /* Create a hashed environment for value-index pairs.
      Members inherit PROTECTion from the env.
    */
-  cmd = PROTECT(lang1 (install ("new.env")));
-  env = PROTECT(eval (cmd, R_BaseEnv));
+  env = PROTECT(R_NewEnv(R_BaseEnv, 1, 29));
 
   /* Read values and names of netcdf enum members.
      Store names as R factor levels.

--- a/tools/convert.m4
+++ b/tools/convert.m4
@@ -1317,8 +1317,7 @@ R_nc_enum_factor (R_nc_buf *io)
   /* Create a hashed environment for value-index pairs.
      Members inherit PROTECTion from the env.
    */
-  cmd = PROTECT(lang1 (install ("new.env")));
-  env = PROTECT(eval (cmd, R_BaseEnv));
+  env = PROTECT(R_NewEnv(R_BaseEnv, 1, 29));
 
   /* Read values and names of netcdf enum members.
      Store names as R factor levels.

--- a/tools/convert.m4
+++ b/tools/convert.m4
@@ -1317,7 +1317,8 @@ R_nc_enum_factor (R_nc_buf *io)
   /* Create a hashed environment for value-index pairs.
      Members inherit PROTECTion from the env.
    */
-  env = PROTECT(R_NewEnv(R_BaseEnv, 1, 29));
+  cmd = PROTECT(lang1 (install ("new.env")));
+  env = PROTECT(eval (cmd, R_BaseEnv));
 
   /* Read values and names of netcdf enum members.
      Store names as R factor levels.

--- a/tools/convert.m4
+++ b/tools/convert.m4
@@ -1358,7 +1358,7 @@ R_nc_enum_factor (R_nc_buf *io)
   any_undef = 0;
   for (ifac=0, inval=io->cbuf; ifac<nfac; ifac++, inval+=size) {
     symbol = PROTECT(R_nc_char_symbol (inval, size, work));
-    index = findVarInFrame3 (env, symbol, TRUE);
+    index = findVar (symbol, env);
     UNPROTECT(1);
     if (index == R_UnboundValue) {
       /* Convert undefined enum values to NA,


### PR DESCRIPTION
R-devel warns that `Rf_findVarInFrame3` is not part of the public R API, so we replace it.