### PR TITLE
Do not use nc-config compiler by default

### DIFF
--- a/.github/workflows/check-linux-mpi.yaml
+++ b/.github/workflows/check-linux-mpi.yaml
@@ -119,7 +119,7 @@ jobs:
           mpicc="mpicc.${{ matrix.config.mpi }}"
           mpiexec="mpiexec.${{ matrix.config.mpi }}"
           R CMD check --no-manual \
-            --install-args="--configure-args='--with-mpiexec=$mpiexec'" \
+            --install-args="--configure-args='--with-cc=$mpicc --with-mpiexec=$mpiexec'" \
             RNetCDF_*.*-*.tar.gz
           echo ::endgroup::
         shell: bash

--- a/INSTALL
+++ b/INSTALL
@@ -46,7 +46,7 @@ Some R installations prepend the R library directory when linking the RNetCDF
 shared library, which may cause problems in rare cases when unwanted versions 
 of other libraries are installed in the same directory. A possible solution 
 involves passing the full pathname of the desired library through the LIBS 
-variable, as explained below.
+variable, as explained next.
 
 Note that libraries may be specified in LIBS in a few different ways. The most 
 common way is '-l<libname>' as shown above, and the compiler will typically 
@@ -74,12 +74,15 @@ Most MPI installations provide a compiler driver (e.g. mpicc) that simplifies
 the building of MPI software. This involves setting paths to headers and 
 libraries, as well as linking libraries, in ways that may depend on compiler 
 flags. If an MPI compiler driver was used to install the NetCDF library,
-this will often be reported by nc-config, which is used in the configure
-script by default.
+this will often be reported by command "nc-config --cc".
 
-An alternative compiler can be specified (if needed) using the configure
-script option --with-cc. This option overrides the compilers reported by R
-and nc-config.
+Although nc-config is used by default in the RNetCDF configure script, the
+compiler reported by nc-config may not be compatible with R headers, so it
+cannot be used automatically when building RNetCDF. Users can specify an
+alternative compiler (e.g. mpicc) using the configure script option
+--with-cc. This option overrides the compiler used to build R, and users
+are advised to check the installation log messages for warnings that indicate
+incompatibilities with R headers or RNetCDF code.
 
 Note that the NetCDF library supports several distinct file formats, and 
 parallel I/O support is implemented separately for netcdf4 (hdf5) format and 
@@ -93,7 +96,7 @@ R CMD INSTALL Example
 =====================
 
 R CMD INSTALL --configure-args="CPPFLAGS=-I/sw/include \
-    LDFLAGS=-L/sw/lib LIBS=-lhdf5 --with-mpiexec=mpiexec" \
+    LDFLAGS=-L/sw/lib LIBS=-lhdf5 --with-cc=mpicc --with-mpiexec=mpiexec" \
     RNetCDF_2.10-2.tar.gz
 
 

--- a/configure
+++ b/configure
@@ -3977,8 +3977,10 @@ fi
 if test "x${have_nc_config}" = xyes
 then :
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Check compiler/linker variables from nc-config:" >&5
-printf "%s\n" "$as_me: Check compiler/linker variables from nc-config:" >&6;}
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Checking compiler/linker variables from nc-config" >&5
+printf "%s\n" "$as_me: Checking compiler/linker variables from nc-config" >&6;}
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: To skip nc-config, use --without-nc-config" >&5
+printf "%s\n" "$as_me: To skip nc-config, use --without-nc-config" >&6;}
 
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking nc-config --cflags" >&5
 printf %s "checking nc-config --cflags... " >&6; }
@@ -4155,8 +4157,10 @@ fi
 if test "x${have_pkg_config}" = xyes
 then :
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Check compiler/linker variables from pkg-config:" >&5
-printf "%s\n" "$as_me: Check compiler/linker variables from pkg-config:" >&6;}
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Checking compiler/linker variables from pkg-config" >&5
+printf "%s\n" "$as_me: Checking compiler/linker variables from pkg-config" >&6;}
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: To skip pkg-config, use --without-pkg-config" >&5
+printf "%s\n" "$as_me: To skip pkg-config, use --without-pkg-config" >&6;}
 
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking pkg-config --cflags netcdf" >&5
 printf %s "checking pkg-config --cflags netcdf... " >&6; }
@@ -6639,12 +6643,6 @@ fi
 
 done
 
-if test "$has_mpi" != TRUE
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: MPI not available. If needed, specify MPI compiler using --with-cc." >&5
-printf "%s\n" "$as_me: WARNING: MPI not available. If needed, specify MPI compiler using --with-cc." >&2;}
-fi
-
 # Parallel I/O support in NetCDF:
 if test "$has_mpi" = TRUE
 then :
@@ -6776,8 +6774,10 @@ fi
 else case e in #(
   e)
     has_parallel=FALSE
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: NetCDF parallel I/O requires MPI" >&5
-printf "%s\n" "$as_me: WARNING: NetCDF parallel I/O requires MPI" >&2;}
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: MPI not found - RNetCDF parallel I/O support is not enabled." >&5
+printf "%s\n" "$as_me: WARNING: MPI not found - RNetCDF parallel I/O support is not enabled." >&2;}
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: If NetCDF was built with an MPI compiler, specify the compiler via --with-cc" >&5
+printf "%s\n" "$as_me: If NetCDF was built with an MPI compiler, specify the compiler via --with-cc" >&6;}
    ;;
 esac
 fi

--- a/configure
+++ b/configure
@@ -3980,23 +3980,6 @@ then :
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Check compiler/linker variables from nc-config:" >&5
 printf "%s\n" "$as_me: Check compiler/linker variables from nc-config:" >&6;}
 
-    SAVE_CC="$CC"
-    if test -z "${ARG_CC}"
-then :
-
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking nc-config --cc" >&5
-printf %s "checking nc-config --cc... " >&6; }
-        NC_CC=`nc-config --cc`
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${NC_CC}" >&5
-printf "%s\n" "${NC_CC}" >&6; }
-
-        CC="${NC_CC}"
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Specify --with-cc if a different compiler is needed" >&5
-printf "%s\n" "$as_me: Specify --with-cc if a different compiler is needed" >&6;}
-
-
-fi
-
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking nc-config --cflags" >&5
 printf %s "checking nc-config --cflags... " >&6; }
     NC_CFLAGS=`nc-config --cflags`
@@ -4107,8 +4090,7 @@ else case e in #(
 printf "%s\n" "$as_me: WARNING: Ignoring broken nc-config" >&2;}
         # Show later code that nc-config settings were not used:
         have_nc_config=no
-        # Restore CC, CFLAGS and LIBS for later tests:
-        CC="${SAVE_CC}"
+        # Restore CFLAGS and LIBS for later tests:
         CFLAGS="${R_CFLAGS}"
         LIBS=""
 
@@ -6659,8 +6641,8 @@ done
 
 if test "$has_mpi" != TRUE
 then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: MPI not available. Specify --with-cc if needed." >&5
-printf "%s\n" "$as_me: WARNING: MPI not available. Specify --with-cc if needed." >&2;}
+  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: MPI not available. If needed, specify MPI compiler using --with-cc." >&5
+printf "%s\n" "$as_me: WARNING: MPI not available. If needed, specify MPI compiler using --with-cc." >&2;}
 fi
 
 # Parallel I/O support in NetCDF:

--- a/configure
+++ b/configure
@@ -6776,8 +6776,8 @@ else case e in #(
     has_parallel=FALSE
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: MPI not found - RNetCDF parallel I/O support is not enabled." >&5
 printf "%s\n" "$as_me: WARNING: MPI not found - RNetCDF parallel I/O support is not enabled." >&2;}
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: If NetCDF was built with an MPI compiler, specify the compiler via --with-cc" >&5
-printf "%s\n" "$as_me: If NetCDF was built with an MPI compiler, specify the compiler via --with-cc" >&6;}
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: If NetCDF was built with an MPI compiler, try the compiler via --with-cc" >&5
+printf "%s\n" "$as_me: If NetCDF was built with an MPI compiler, try the compiler via --with-cc" >&6;}
    ;;
 esac
 fi

--- a/configure
+++ b/configure
@@ -6643,6 +6643,42 @@ fi
 
 done
 
+ac_fn_check_decl "$LINENO" "MPI_INFO_NULL" "ac_cv_have_decl_MPI_INFO_NULL" "#include <mpi.h>
+" "$ac_c_undeclared_builtin_options" "CFLAGS"
+if test "x$ac_cv_have_decl_MPI_INFO_NULL" = xyes
+then :
+  ac_have_decl=1
+else case e in #(
+  e) ac_have_decl=0 ;;
+esac
+fi
+printf "%s\n" "#define HAVE_DECL_MPI_INFO_NULL $ac_have_decl" >>confdefs.h
+if test $ac_have_decl = 1
+then :
+
+else case e in #(
+  e) has_mpi=FALSE ;;
+esac
+fi
+ac_fn_check_decl "$LINENO" "MPI_Info_c2f" "ac_cv_have_decl_MPI_Info_c2f" "#include <mpi.h>
+" "$ac_c_undeclared_builtin_options" "CFLAGS"
+if test "x$ac_cv_have_decl_MPI_Info_c2f" = xyes
+then :
+  ac_have_decl=1
+else case e in #(
+  e) ac_have_decl=0 ;;
+esac
+fi
+printf "%s\n" "#define HAVE_DECL_MPI_INFO_C2F $ac_have_decl" >>confdefs.h
+if test $ac_have_decl = 1
+then :
+
+else case e in #(
+  e) has_mpi=FALSE ;;
+esac
+fi
+
+
 # Parallel I/O support in NetCDF:
 if test "$has_mpi" = TRUE
 then :
@@ -6695,44 +6731,6 @@ else case e in #(
 esac
 fi
 printf "%s\n" "#define HAVE_DECL_NC_INDEPENDENT $ac_have_decl" >>confdefs.h
-if test $ac_have_decl = 1
-then :
-
-else case e in #(
-  e) has_parallel=FALSE ;;
-esac
-fi
-
-
-    ac_fn_check_decl "$LINENO" "MPI_INFO_NULL" "ac_cv_have_decl_MPI_INFO_NULL" "#include <mpi.h>
-
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_MPI_INFO_NULL" = xyes
-then :
-  ac_have_decl=1
-else case e in #(
-  e) ac_have_decl=0 ;;
-esac
-fi
-printf "%s\n" "#define HAVE_DECL_MPI_INFO_NULL $ac_have_decl" >>confdefs.h
-if test $ac_have_decl = 1
-then :
-
-else case e in #(
-  e) has_parallel=FALSE ;;
-esac
-fi
-ac_fn_check_decl "$LINENO" "MPI_Info_c2f" "ac_cv_have_decl_MPI_Info_c2f" "#include <mpi.h>
-
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_MPI_Info_c2f" = xyes
-then :
-  ac_have_decl=1
-else case e in #(
-  e) ac_have_decl=0 ;;
-esac
-fi
-printf "%s\n" "#define HAVE_DECL_MPI_INFO_C2F $ac_have_decl" >>confdefs.h
 if test $ac_have_decl = 1
 then :
 

--- a/configure.ac
+++ b/configure.ac
@@ -425,6 +425,9 @@ AC_CHECK_HEADERS([mpi.h], [], [has_mpi=FALSE])
 
 AC_CHECK_FUNCS([MPI_Init], [], [has_mpi=FALSE])
 
+AC_CHECK_DECLS([MPI_INFO_NULL, MPI_Info_c2f], [], [has_mpi=FALSE],
+  [#include <mpi.h>])
+
 # Parallel I/O support in NetCDF:
 AS_IF([test "$has_mpi" = TRUE],
   [
@@ -436,10 +439,6 @@ AS_IF([test "$has_mpi" = TRUE],
     AC_CHECK_DECLS([NC_COLLECTIVE, NC_INDEPENDENT], [], [has_parallel=FALSE],
       [#include <netcdf.h>
        #include <netcdf_par.h>
-      ])
-
-    AC_CHECK_DECLS([MPI_INFO_NULL, MPI_Info_c2f], [], [has_parallel=FALSE],
-      [#include <mpi.h>
       ])
 
     AC_CHECK_FUNCS(

--- a/configure.ac
+++ b/configure.ac
@@ -127,18 +127,6 @@ AS_IF([test "x${have_nc_config}" = xyes],
   [
     AC_MSG_NOTICE([Check compiler/linker variables from nc-config:])
 
-    SAVE_CC="$CC"
-    AS_IF([test -z "${ARG_CC}"],
-      [
-        AC_MSG_CHECKING([nc-config --cc])
-        NC_CC=`nc-config --cc`
-        AC_MSG_RESULT([${NC_CC}])
-        
-        CC="${NC_CC}"
-        AC_MSG_NOTICE([Specify --with-cc if a different compiler is needed])
-      ]
-    )
-
     AC_MSG_CHECKING([nc-config --cflags])
     NC_CFLAGS=`nc-config --cflags`
     AC_MSG_RESULT([${NC_CFLAGS}])
@@ -190,8 +178,7 @@ AS_IF([test "x${have_nc_config}" = xyes],
         AC_MSG_WARN([Ignoring broken nc-config])
         # Show later code that nc-config settings were not used:
         have_nc_config=no
-        # Restore CC, CFLAGS and LIBS for later tests:
-        CC="${SAVE_CC}"
+        # Restore CFLAGS and LIBS for later tests:
         CFLAGS="${R_CFLAGS}"
         LIBS=""
       ]
@@ -437,7 +424,7 @@ AC_CHECK_HEADERS([mpi.h], [], [has_mpi=FALSE])
 AC_CHECK_FUNCS([MPI_Init], [], [has_mpi=FALSE])
 
 AS_IF([test "$has_mpi" != TRUE],
-  [AC_MSG_WARN([MPI not available. Specify --with-cc if needed.])])
+  [AC_MSG_WARN([MPI not available. If needed, specify MPI compiler using --with-cc.])])
 
 # Parallel I/O support in NetCDF:
 AS_IF([test "$has_mpi" = TRUE],

--- a/configure.ac
+++ b/configure.ac
@@ -453,7 +453,7 @@ AS_IF([test "$has_mpi" = TRUE],
   ], [
     has_parallel=FALSE
     AC_MSG_WARN([MPI not found - RNetCDF parallel I/O support is not enabled.])
-    AC_MSG_NOTICE([If NetCDF was built with an MPI compiler, specify the compiler via --with-cc])
+    AC_MSG_NOTICE([If NetCDF was built with an MPI compiler, try the compiler via --with-cc])
   ])
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -125,7 +125,8 @@ AS_IF([test "x${with_nc_config}" = xyes],
 # Get cflags and libs from nc-config and check if they work:
 AS_IF([test "x${have_nc_config}" = xyes],
   [
-    AC_MSG_NOTICE([Check compiler/linker variables from nc-config:])
+    AC_MSG_NOTICE([Checking compiler/linker variables from nc-config])
+    AC_MSG_NOTICE([To skip nc-config, use --without-nc-config])
 
     AC_MSG_CHECKING([nc-config --cflags])
     NC_CFLAGS=`nc-config --cflags`
@@ -220,7 +221,8 @@ AS_IF([test "x${with_pkg_config}" = xyes],
 # Get cflags and libs from pkg-config and check if they work:
 AS_IF([test "x${have_pkg_config}" = xyes],
   [
-    AC_MSG_NOTICE([Check compiler/linker variables from pkg-config:])
+    AC_MSG_NOTICE([Checking compiler/linker variables from pkg-config])
+    AC_MSG_NOTICE([To skip pkg-config, use --without-pkg-config])
 
     AC_MSG_CHECKING([pkg-config --cflags netcdf])
     PC_CFLAGS=`pkg-config --cflags netcdf`
@@ -423,9 +425,6 @@ AC_CHECK_HEADERS([mpi.h], [], [has_mpi=FALSE])
 
 AC_CHECK_FUNCS([MPI_Init], [], [has_mpi=FALSE])
 
-AS_IF([test "$has_mpi" != TRUE],
-  [AC_MSG_WARN([MPI not available. If needed, specify MPI compiler using --with-cc.])])
-
 # Parallel I/O support in NetCDF:
 AS_IF([test "$has_mpi" = TRUE],
   [
@@ -453,7 +452,8 @@ AS_IF([test "$has_mpi" = TRUE],
 
   ], [
     has_parallel=FALSE
-    AC_MSG_WARN([NetCDF parallel I/O requires MPI])
+    AC_MSG_WARN([MPI not found - RNetCDF parallel I/O support is not enabled.])
+    AC_MSG_NOTICE([If NetCDF was built with an MPI compiler, specify the compiler via --with-cc])
   ])
 
 


### PR DESCRIPTION
On some systems, the compiler reported by `nc-config --cc` may not be compatible with R headers. Warnings may be issued during package installation and/or the package may not work. An example of this was reported by Prof Ripley, where the compiler reported by nc-config was ancient and R was built with a newer compiler.

The compiler from nc-config is only of interest for enabling MPI. This is unlikely to be a requirement for most RNetCDF users, so it is better to use the R compiler by default. For the rarer installations that require parallel I/O, the following methods are provided:

* Specify an MPI compiler via configure option `--with-cc`. (This compiler must be compatible with R headers and provide the same MPI libraries as used by NetCDF).
* Disable nc-config and pkg-config via configure options `--without-nc-config` and `--without-pkg-config`, then specify the MPI headers and libraries via variables CPPFLAGS, LDFLAGS and LIBS. (Other header and library paths may also need to be included in these variables).