### PR TITLE
Use new R API functions for environments

### DIFF
--- a/configure
+++ b/configure
@@ -3904,6 +3904,31 @@ fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Operating system is $platform" >&5
 printf "%s\n" "$as_me: Operating system is $platform" >&6;}
 
+#-------------------------------------------------------------------------------#
+#  Test R features                                                              #
+#-------------------------------------------------------------------------------#
+
+ac_fn_check_decl "$LINENO" "R_getVarEx" "ac_cv_have_decl_R_getVarEx" "#include <R.h>
+" "$ac_c_undeclared_builtin_options" "CFLAGS"
+if test "x$ac_cv_have_decl_R_getVarEx" = xyes
+then :
+  ac_have_decl=1
+else case e in #(
+  e) ac_have_decl=0 ;;
+esac
+fi
+printf "%s\n" "#define HAVE_DECL_R_GETVAREX $ac_have_decl" >>confdefs.h
+ac_fn_check_decl "$LINENO" "R_NewEnv" "ac_cv_have_decl_R_NewEnv" "#include <R.h>
+" "$ac_c_undeclared_builtin_options" "CFLAGS"
+if test "x$ac_cv_have_decl_R_NewEnv" = xyes
+then :
+  ac_have_decl=1
+else case e in #(
+  e) ac_have_decl=0 ;;
+esac
+fi
+printf "%s\n" "#define HAVE_DECL_R_NEWENV $ac_have_decl" >>confdefs.h
+
 
 #-------------------------------------------------------------------------------#
 #  Prepend compiler/linker variables from nc-config (if enabled)                #

--- a/configure.ac
+++ b/configure.ac
@@ -105,6 +105,11 @@ AC_CHECK_DECLS([_WIN32],
      [platform=Unix-alike])])
 AC_MSG_NOTICE([Operating system is $platform])
 
+#-------------------------------------------------------------------------------#
+#  Test R features                                                              #
+#-------------------------------------------------------------------------------#
+
+AC_CHECK_DECLS([R_getVarEx, R_NewEnv], [], [], [#include <R.h>])
 
 #-------------------------------------------------------------------------------#
 #  Prepend compiler/linker variables from nc-config (if enabled)                #

--- a/src/convert.c
+++ b/src/convert.c
@@ -6901,7 +6901,7 @@ R_nc_enum_factor (R_nc_buf *io)
   /* Create a hashed environment for value-index pairs.
      Members inherit PROTECTion from the env.
    */
-#ifdef HAVE_DECL_R_NEWENV
+#if defined(HAVE_DECL_R_NEWENV) && (HAVE_DECL_R_NEWENV == 1)
   env = PROTECT(R_NewEnv(R_BaseEnv, TRUE, 0));
 #else
   cmd = PROTECT(lang1 (install ("new.env")));
@@ -6946,7 +6946,7 @@ R_nc_enum_factor (R_nc_buf *io)
   any_undef = 0;
   for (ifac=0, inval=io->cbuf; ifac<nfac; ifac++, inval+=size) {
     symbol = PROTECT(R_nc_char_symbol (inval, size, work));
-#ifdef HAVE_DECL_R_GETVAREX
+#if defined(HAVE_DECL_R_GETVAREX) && (HAVE_DECL_R_GETVAREX == 1)
     index = R_getVarEx(symbol, env, FALSE, R_UnboundValue);
 #else
     index = findVar (symbol, env);

--- a/src/convert.c
+++ b/src/convert.c
@@ -6901,8 +6901,12 @@ R_nc_enum_factor (R_nc_buf *io)
   /* Create a hashed environment for value-index pairs.
      Members inherit PROTECTion from the env.
    */
+#ifdef HAVE_DECL_R_NEWENV
+  env = PROTECT(R_NewEnv(R_BaseEnv, TRUE, 0));
+#else
   cmd = PROTECT(lang1 (install ("new.env")));
   env = PROTECT(eval (cmd, R_BaseEnv));
+#endif
 
   /* Read values and names of netcdf enum members.
      Store names as R factor levels.
@@ -6942,7 +6946,11 @@ R_nc_enum_factor (R_nc_buf *io)
   any_undef = 0;
   for (ifac=0, inval=io->cbuf; ifac<nfac; ifac++, inval+=size) {
     symbol = PROTECT(R_nc_char_symbol (inval, size, work));
+#ifdef HAVE_DECL_R_GETVAREX
+    index = R_getVarEx(symbol, env, FALSE, R_UnboundValue);
+#else
     index = findVar (symbol, env);
+#endif
     UNPROTECT(1);
     if (index == R_UnboundValue) {
       /* Convert undefined enum values to NA,

--- a/tools/convert.m4
+++ b/tools/convert.m4
@@ -1317,7 +1317,7 @@ R_nc_enum_factor (R_nc_buf *io)
   /* Create a hashed environment for value-index pairs.
      Members inherit PROTECTion from the env.
    */
-#ifdef HAVE_DECL_R_NEWENV
+#if defined(HAVE_DECL_R_NEWENV) && (HAVE_DECL_R_NEWENV == 1)
   env = PROTECT(R_NewEnv(R_BaseEnv, TRUE, 0));
 #else
   cmd = PROTECT(lang1 (install ("new.env")));
@@ -1362,7 +1362,7 @@ R_nc_enum_factor (R_nc_buf *io)
   any_undef = 0;
   for (ifac=0, inval=io->cbuf; ifac<nfac; ifac++, inval+=size) {
     symbol = PROTECT(R_nc_char_symbol (inval, size, work));
-#ifdef HAVE_DECL_R_GETVAREX
+#if defined(HAVE_DECL_R_GETVAREX) && (HAVE_DECL_R_GETVAREX == 1)
     index = R_getVarEx(symbol, env, FALSE, R_UnboundValue);
 #else
     index = findVar (symbol, env);

--- a/tools/convert.m4
+++ b/tools/convert.m4
@@ -1317,8 +1317,12 @@ R_nc_enum_factor (R_nc_buf *io)
   /* Create a hashed environment for value-index pairs.
      Members inherit PROTECTion from the env.
    */
+#ifdef HAVE_DECL_R_NEWENV
+  env = PROTECT(R_NewEnv(R_BaseEnv, TRUE, 0));
+#else
   cmd = PROTECT(lang1 (install ("new.env")));
   env = PROTECT(eval (cmd, R_BaseEnv));
+#endif
 
   /* Read values and names of netcdf enum members.
      Store names as R factor levels.
@@ -1358,7 +1362,11 @@ R_nc_enum_factor (R_nc_buf *io)
   any_undef = 0;
   for (ifac=0, inval=io->cbuf; ifac<nfac; ifac++, inval+=size) {
     symbol = PROTECT(R_nc_char_symbol (inval, size, work));
+#ifdef HAVE_DECL_R_GETVAREX
+    index = R_getVarEx(symbol, env, FALSE, R_UnboundValue);
+#else
     index = findVar (symbol, env);
+#endif
     UNPROTECT(1);
     if (index == R_UnboundValue) {
       /* Convert undefined enum values to NA,


### PR DESCRIPTION
Recent R versions have added new API functions to replace internal functions that will become private in future R releases. This PR tests for `R_NewEnv` and `R_getVarEx` in configure, and uses them as replacements for legacy code.