### PR TITLE
Close stale file handles before opening new files

### DIFF
--- a/src/dataset.c
+++ b/src/dataset.c
@@ -177,6 +177,9 @@ R_nc_create (SEXP filename, SEXP clobber, SEXP share, SEXP prefill,
 #endif
   }
 
+  /*-- Close any stale netcdf handles that could point to this file -----------*/
+  R_gc();
+
   /*-- Create the file --------------------------------------------------------*/
   filep = R_nc_strarg (filename);
   if (strlen (filep) > 0) {
@@ -297,6 +300,9 @@ R_nc_open (SEXP filename, SEXP write, SEXP share, SEXP prefill,
   } else {
     fillmode = NC_NOFILL;
   }
+
+  /*-- Close any stale netcdf handles that could point to this file -----------*/
+  R_gc();
 
   /*-- Open the file ----------------------------------------------------------*/
   filep = R_nc_strarg (filename);

--- a/tests/RNetCDF-test.R
+++ b/tests/RNetCDF-test.R
@@ -1340,14 +1340,23 @@ for (format in c("classic","offset64","data64","classic4","netcdf4")) {
   y <- var.get.nc(nc, "packvar", unpack=TRUE)
   tally <- testfun(x,y,tally)
 
-  cat("Check that closing any NetCDF handle closes the file for all handles ... ")
+  cat("Check that repeated closing of NetCDF file does not cause error ... ")
   close.nc(nc)
-  y <- try(file.inq.nc(grpinfo$self), silent=TRUE)
-  tally <- testfun(inherits(y, "try-error"), TRUE, tally)  
+  y <- try(close.nc(nc), silent=TRUE)
+  tally <- testfun(inherits(y, "try-error"), FALSE, tally)
+
+  cat("Check that closing any copy of a NetCDF handle closes all copies ... ")
+  nc <- open.nc(ncfile)
+  y <- file.inq.nc(nc)
+  nc2 <- nc
+  close.nc(nc2)
+  y <- try(file.inq.nc(nc), silent=TRUE)
+  tally <- testfun(inherits(y, "try-error"), TRUE, tally)
 
   cat("Check that garbage collector closes file that is not referenced ... ")
+  nc <- open.nc(ncfile)
+  y <- file.inq.nc(nc)
   attr(nc,"handle_ptr") <- NULL # NetCDF objects should not normally be modified
-  rm(grpinfo)
   gc()
   y <- try(file.inq.nc(nc), silent=TRUE)
   tally <- testfun(inherits(y, "try-error"), TRUE, tally)


### PR DESCRIPTION
Occasional crashes have occurred after interrupting functions that opened netcdf files and then opening or editing the same files again. Repeatable cases have been elusive, but the cause may involve garbage collection of stale netcdf file handles. If the stale handles point to files being modified by new handles, the garbage collection will close the stale file handles, possibly corrupting the new files and causing a crash. This PR introduces a possible solution, which is to call the garbage collector before opening new file handles. This should not cause problems, other than potential slowdowns when opening many files in rapid succession (probably a rare use case).

Tests of file closures and their interactions with garbage collection are also improved in this PR.