### PR TITLE
Fix R API feature checks

### DIFF
--- a/configure
+++ b/configure
@@ -3904,52 +3904,6 @@ fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Operating system is $platform" >&5
 printf "%s\n" "$as_me: Operating system is $platform" >&6;}
 
-#-------------------------------------------------------------------------------#
-#  Test R features                                                              #
-#-------------------------------------------------------------------------------#
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: Checking R API features" >&5
-printf "%s\n" "$as_me: Checking R API features" >&6;}
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking CPPFLAGS for compiling R headers" >&5
-printf %s "checking CPPFLAGS for compiling R headers... " >&6; }
-R_H_CPPFLAGS=`"${R_HOME}/bin/R" CMD config --cppflags`
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${R_H_CPPFLAGS}" >&5
-printf "%s\n" "${R_H_CPPFLAGS}" >&6; }
-
-SAVE_CPPFLAGS="$CPPFLAGS"
-CPPFLAGS="${R_H_CPPFLAGS} $CPPFLAGS"
-
-ac_fn_check_decl "$LINENO" "R_getVarEx" "ac_cv_have_decl_R_getVarEx" "
-#include <R.h>
-#include <Rinternals.h>
-
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_R_getVarEx" = xyes
-then :
-  ac_have_decl=1
-else case e in #(
-  e) ac_have_decl=0 ;;
-esac
-fi
-printf "%s\n" "#define HAVE_DECL_R_GETVAREX $ac_have_decl" >>confdefs.h
-ac_fn_check_decl "$LINENO" "R_NewEnv" "ac_cv_have_decl_R_NewEnv" "
-#include <R.h>
-#include <Rinternals.h>
-
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_R_NewEnv" = xyes
-then :
-  ac_have_decl=1
-else case e in #(
-  e) ac_have_decl=0 ;;
-esac
-fi
-printf "%s\n" "#define HAVE_DECL_R_NEWENV $ac_have_decl" >>confdefs.h
-
-
-CPPFLAGS="${SAVE_CPPFLAGS}"
-
 
 #-------------------------------------------------------------------------------#
 #  Prepend compiler/linker variables from nc-config (if enabled)                #

--- a/configure
+++ b/configure
@@ -3908,7 +3908,22 @@ printf "%s\n" "$as_me: Operating system is $platform" >&6;}
 #  Test R features                                                              #
 #-------------------------------------------------------------------------------#
 
-ac_fn_check_decl "$LINENO" "R_getVarEx" "ac_cv_have_decl_R_getVarEx" "#include <R.h>
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: Checking R API features" >&5
+printf "%s\n" "$as_me: Checking R API features" >&6;}
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking CPPFLAGS for compiling R headers" >&5
+printf %s "checking CPPFLAGS for compiling R headers... " >&6; }
+R_H_CPPFLAGS=`"${R_HOME}/bin/R" CMD config --cppflags`
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${R_H_CPPFLAGS}" >&5
+printf "%s\n" "${R_H_CPPFLAGS}" >&6; }
+
+SAVE_CPPFLAGS="$CPPFLAGS"
+CPPFLAGS="${R_H_CPPFLAGS} $CPPFLAGS"
+
+ac_fn_check_decl "$LINENO" "R_getVarEx" "ac_cv_have_decl_R_getVarEx" "
+#include <R.h>
+#include <Rinternals.h>
+
 " "$ac_c_undeclared_builtin_options" "CFLAGS"
 if test "x$ac_cv_have_decl_R_getVarEx" = xyes
 then :
@@ -3918,7 +3933,10 @@ else case e in #(
 esac
 fi
 printf "%s\n" "#define HAVE_DECL_R_GETVAREX $ac_have_decl" >>confdefs.h
-ac_fn_check_decl "$LINENO" "R_NewEnv" "ac_cv_have_decl_R_NewEnv" "#include <R.h>
+ac_fn_check_decl "$LINENO" "R_NewEnv" "ac_cv_have_decl_R_NewEnv" "
+#include <R.h>
+#include <Rinternals.h>
+
 " "$ac_c_undeclared_builtin_options" "CFLAGS"
 if test "x$ac_cv_have_decl_R_NewEnv" = xyes
 then :
@@ -3928,6 +3946,9 @@ else case e in #(
 esac
 fi
 printf "%s\n" "#define HAVE_DECL_R_NEWENV $ac_have_decl" >>confdefs.h
+
+
+CPPFLAGS="${SAVE_CPPFLAGS}"
 
 
 #-------------------------------------------------------------------------------#

--- a/configure.ac
+++ b/configure.ac
@@ -105,26 +105,6 @@ AC_CHECK_DECLS([_WIN32],
      [platform=Unix-alike])])
 AC_MSG_NOTICE([Operating system is $platform])
 
-#-------------------------------------------------------------------------------#
-#  Test R features                                                              #
-#-------------------------------------------------------------------------------#
-
-AC_MSG_NOTICE([Checking R API features])
-
-AC_MSG_CHECKING([CPPFLAGS for compiling R headers])
-R_H_CPPFLAGS=`"${R_HOME}/bin/R" CMD config --cppflags`
-AC_MSG_RESULT([${R_H_CPPFLAGS}])
-
-SAVE_CPPFLAGS="$CPPFLAGS"
-CPPFLAGS="${R_H_CPPFLAGS} $CPPFLAGS"
-
-AC_CHECK_DECLS([R_getVarEx, R_NewEnv], [], [], [
-#include <R.h>
-#include <Rinternals.h>
-])
-
-CPPFLAGS="${SAVE_CPPFLAGS}"
-
 
 #-------------------------------------------------------------------------------#
 #  Prepend compiler/linker variables from nc-config (if enabled)                #

--- a/configure.ac
+++ b/configure.ac
@@ -109,7 +109,22 @@ AC_MSG_NOTICE([Operating system is $platform])
 #  Test R features                                                              #
 #-------------------------------------------------------------------------------#
 
-AC_CHECK_DECLS([R_getVarEx, R_NewEnv], [], [], [#include <R.h>])
+AC_MSG_NOTICE([Checking R API features])
+
+AC_MSG_CHECKING([CPPFLAGS for compiling R headers])
+R_H_CPPFLAGS=`"${R_HOME}/bin/R" CMD config --cppflags`
+AC_MSG_RESULT([${R_H_CPPFLAGS}])
+
+SAVE_CPPFLAGS="$CPPFLAGS"
+CPPFLAGS="${R_H_CPPFLAGS} $CPPFLAGS"
+
+AC_CHECK_DECLS([R_getVarEx, R_NewEnv], [], [], [
+#include <R.h>
+#include <Rinternals.h>
+])
+
+CPPFLAGS="${SAVE_CPPFLAGS}"
+
 
 #-------------------------------------------------------------------------------#
 #  Prepend compiler/linker variables from nc-config (if enabled)                #

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -32,14 +32,6 @@
    don't. */
 #undef HAVE_DECL_NC_PERSIST
 
-/* Define to 1 if you have the declaration of 'R_getVarEx', and to 0 if you
-   don't. */
-#undef HAVE_DECL_R_GETVAREX
-
-/* Define to 1 if you have the declaration of 'R_NewEnv', and to 0 if you
-   don't. */
-#undef HAVE_DECL_R_NEWENV
-
 /* Define to 1 if you have the declaration of '_WIN32', and to 0 if you don't.
    */
 #undef HAVE_DECL__WIN32

--- a/src/convert.c
+++ b/src/convert.c
@@ -6973,7 +6973,11 @@ R_nc_enum_factor (R_nc_buf *io)
   }
 
   /* Allow garbage collection of env and levels */
+#if defined(R_VERSION) && R_VERSION >= R_Version(4, 1, 0)
+  UNPROTECT(2);
+#else
   UNPROTECT(3);
+#endif
 }
 
 

--- a/src/convert.c
+++ b/src/convert.c
@@ -48,6 +48,7 @@
 
 #include <R.h>
 #include <Rinternals.h>
+#include <Rversion.h>
 
 #include <netcdf.h>
 
@@ -6884,7 +6885,10 @@ R_nc_char_symbol (char *in, size_t size, char *work)
 static void
 R_nc_enum_factor (R_nc_buf *io)
 {
-  SEXP levels, env, cmd, symbol, index;
+  SEXP levels, env, symbol, index;
+#if !defined(R_VERSION) || R_VERSION < R_Version(4, 1, 0)
+  SEXP cmd;
+#endif
   size_t size, nmem, ifac, nfac;
   char *memname, *memval, *work, *inval;
   int ncid, imem, imemmax, *out, any_undef;
@@ -6903,7 +6907,7 @@ R_nc_enum_factor (R_nc_buf *io)
   /* Create a hashed environment for value-index pairs.
      Members inherit PROTECTion from the env.
    */
-#if defined(HAVE_DECL_R_NEWENV) && (HAVE_DECL_R_NEWENV == 1)
+#if defined(R_VERSION) && R_VERSION >= R_Version(4, 1, 0)
   env = PROTECT(R_NewEnv(R_BaseEnv, TRUE, 0));
 #else
   cmd = PROTECT(lang1 (install ("new.env")));
@@ -6948,7 +6952,7 @@ R_nc_enum_factor (R_nc_buf *io)
   any_undef = 0;
   for (ifac=0, inval=io->cbuf; ifac<nfac; ifac++, inval+=size) {
     symbol = PROTECT(R_nc_char_symbol (inval, size, work));
-#if defined(HAVE_DECL_R_GETVAREX) && (HAVE_DECL_R_GETVAREX == 1)
+#if defined(R_VERSION) && R_VERSION >= R_Version(4, 5, 0)
     index = R_getVarEx(symbol, env, FALSE, R_UnboundValue);
 #else
     index = findVar (symbol, env);

--- a/tools/convert.m4
+++ b/tools/convert.m4
@@ -1389,7 +1389,11 @@ R_nc_enum_factor (R_nc_buf *io)
   }
 
   /* Allow garbage collection of env and levels */
+#if defined(R_VERSION) && R_VERSION >= R_Version(4, 1, 0)
+  UNPROTECT(2);
+#else
   UNPROTECT(3);
+#endif
 }
 
 

--- a/tools/convert.m4
+++ b/tools/convert.m4
@@ -49,6 +49,7 @@ dnl Insert warning into generated C code:
 
 #include <R.h>
 #include <Rinternals.h>
+#include <Rversion.h>
 
 #include <netcdf.h>
 
@@ -1300,7 +1301,10 @@ R_nc_char_symbol (char *in, size_t size, char *work)
 static void
 R_nc_enum_factor (R_nc_buf *io)
 {
-  SEXP levels, env, cmd, symbol, index;
+  SEXP levels, env, symbol, index;
+#if !defined(R_VERSION) || R_VERSION < R_Version(4, 1, 0)
+  SEXP cmd;
+#endif
   size_t size, nmem, ifac, nfac;
   char *memname, *memval, *work, *inval;
   int ncid, imem, imemmax, *out, any_undef;
@@ -1319,7 +1323,7 @@ R_nc_enum_factor (R_nc_buf *io)
   /* Create a hashed environment for value-index pairs.
      Members inherit PROTECTion from the env.
    */
-#if defined(HAVE_DECL_R_NEWENV) && (HAVE_DECL_R_NEWENV == 1)
+#if defined(R_VERSION) && R_VERSION >= R_Version(4, 1, 0)
   env = PROTECT(R_NewEnv(R_BaseEnv, TRUE, 0));
 #else
   cmd = PROTECT(lang1 (install ("new.env")));
@@ -1364,7 +1368,7 @@ R_nc_enum_factor (R_nc_buf *io)
   any_undef = 0;
   for (ifac=0, inval=io->cbuf; ifac<nfac; ifac++, inval+=size) {
     symbol = PROTECT(R_nc_char_symbol (inval, size, work));
-#if defined(HAVE_DECL_R_GETVAREX) && (HAVE_DECL_R_GETVAREX == 1)
+#if defined(R_VERSION) && R_VERSION >= R_Version(4, 5, 0)
     index = R_getVarEx(symbol, env, FALSE, R_UnboundValue);
 #else
     index = findVar (symbol, env);


### PR DESCRIPTION
Tests of new R API functions appeared to work in #159, but in fact, the functions were not detected even in the latest R version. This was because `R CMD config CPPFLAGS` does not set the include path for R headers. A separate command `R CMD config --cppflags` is provided for that purpose.

**Update**: Although the above approach worked, a simpler approach was taken, based on selecting R API features via the R version.